### PR TITLE
Remove unneeded xfail markers for UKy flowsheet tests

### DIFF
--- a/src/prommis/uky/tests/test_uky_flowsheet.py
+++ b/src/prommis/uky/tests/test_uky_flowsheet.py
@@ -59,13 +59,11 @@ class TestUKyFlowsheet:
         set_operating_conditions(m)
         return m
 
-    @pytest.mark.known_issue(6)
     @pytest.mark.component
     def test_structural_issues(self, model):
         dt = DiagnosticsToolbox(model)
         dt.assert_no_structural_warnings()
 
-    @pytest.mark.known_issue(6)
     @pytest.mark.unit
     def test_build_flowsheet(self, model):
         assert isinstance(model.fs, FlowsheetBlock)
@@ -133,7 +131,6 @@ class TestUKyFlowsheet:
 
         assert degrees_of_freedom(model) == 0
 
-    @pytest.mark.known_issue(6)
     @pytest.mark.unit
     def test_set_dof(self, model):
         set_scaling(model)
@@ -141,7 +138,6 @@ class TestUKyFlowsheet:
 
         assert degrees_of_freedom(model) == 0
 
-    @pytest.mark.known_issue(6)
     @pytest.mark.unit
     def test_initialize_flowsheet(self, model):
         initialize_system(model)
@@ -152,7 +148,6 @@ class TestUKyFlowsheet:
     def test_unit_consistency(self, model):
         assert_units_consistent(model)
 
-    @pytest.mark.known_issue(6)
     @pytest.mark.unit
     def test_solve_flowsheet(self, model):
         solve(model)


### PR DESCRIPTION
## Related to #6

The pytest markers causing the UKy to be `xfail`ed aren't actually needed; in other words, the tests actually pass resulting in a status of `xpass`

## Changes proposed in this PR:

- Remove markers since tests actually pass

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
