### PR TITLE
Add WaterTAP dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
     "idaes-pse >= 2.3.0rc1",
     "pyomo >= 6.7.0",
 ]
+[project.optional-dependencies]
+watertap = [
+    # TODO: update once 0.11.0 is available
+    "watertap==0.11.0rc1",
+]
 
 [tool.setuptools_scm]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ nbmake==1.4.6
 
 idaes-pse @ git+https://github.com/IDAES/idaes-pse@main
 
---editable .
+--editable .[watertap]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,6 @@ jupyter-book==0.15.*
 isort
 nbmake==1.4.6
 
-idaes-pse @ git+https://github.com/IDAES/idaes-pse@main
+idaes-pse==2.3.0
 
 --editable .[watertap]


### PR DESCRIPTION
## Addresses Issue: #25

## Changes proposed in this PR:
- Add WaterTAP dependency as `watertap` `extras_require` target (included by default in `requirements-dev.txt`)
- Change `idaes-pse` dev requirement to 2.3.0 (from `IDAES/idaes-pse@main`) to avoid conflicts with WaterTAP's own `idaes-pse` requirement

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
