### PR TITLE
Pr costing

### DIFF
--- a/src/prommis/uky/costing/REE_costing_parameters.json
+++ b/src/prommis/uky/costing/REE_costing_parameters.json
@@ -588,9 +588,9 @@
     },
     "2": {
         "2.1": {
-            "Account Name": "HDD Recycling - Shredder",
+            "Account Name": "HDD Recycling - Shredder (2,700 drives per hour)",
             "BEC": 50000.0,
-            "BEC_units": "$2018",
+            "BEC_units": "$2019",
             "Exponent": 1.0,
             "Process Parameter": "Number of Units (dimensionless)",
             "RP Value": 1.0,

--- a/src/prommis/uky/costing/tests/test_ree_costing.py
+++ b/src/prommis/uky/costing/tests/test_ree_costing.py
@@ -1876,9 +1876,9 @@ def test_HDD_Recycling_costing_noOM_usedefaults():
         m.fs.HDD_Recycling_shredder.costing.bare_erected_cost[
             HDD_Recycling_shredder_accounts
         ]
-    ) == pytest.approx(0.05036, rel=1e-4)
+    ) == pytest.approx(0.05000, rel=1e-4)
     assert value(
         m.fs.HDD_Recycling_HD.costing.bare_erected_cost[HDD_Recycling_HD_accounts]
     ) == pytest.approx(0.41035, rel=1e-4)
 
-    assert m.fs.costing.total_plant_cost.value == pytest.approx(3.8231, rel=1e-4)
+    assert m.fs.costing.total_plant_cost.value == pytest.approx(3.8220, rel=1e-4)


### PR DESCRIPTION
## Addresses Issue: 
This is a small PR where I updated the name of the shredder within the costing json file to include its throughput of 2,700 drives per hour, and fixed a mistake where the shredder's BEC_units was in $2018 instead of $2019. I also updated the tests for the new shredder BEC units. Follow-on from PR # 24.

## Summary/Motivation:
It is valuable for future users to know the throughput of the shredder to determine how many units are needed. Additionally, updating the BEC_units will make the costing of this unit more accurate.

## Changes proposed in this PR:
- Changed name of HDD recycling shredder unit to include its throughput.
- Fixed an error where the HDD recycling shredder had BEC units in terms of $2018 instead of $2019.
- Updated tests for new HDD recycling shredder's BEC units.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
