### PR TITLE
Support Chemicals and Waste Cost Expressions

### DIFF
--- a/src/prommis/uky/costing/ree_plant_capcost.py
+++ b/src/prommis/uky/costing/ree_plant_capcost.py
@@ -717,18 +717,32 @@ class QGESSCostingData(FlowsheetCostingBlockData):
         # define additional chemicals cost
         if additional_chemicals_cost is not None:
             if type(additional_chemicals_cost) in [Expression, ScalarExpression]:
-                if pyunits.get_units(additional_chemicals_cost) == pyunits.dimensionless:
-                    self.additional_chemicals_cost = Expression(expr=additional_chemicals_cost.expr * CE_index_units)
+                if (
+                    pyunits.get_units(additional_chemicals_cost)
+                    == pyunits.dimensionless
+                ):
+                    self.additional_chemicals_cost = Expression(
+                        expr=additional_chemicals_cost.expr * CE_index_units
+                    )
                 else:
                     self.additional_chemicals_cost = Expression(
-                        expr=pyunits.convert(additional_chemicals_cost.expr, to_units=CE_index_units)
+                        expr=pyunits.convert(
+                            additional_chemicals_cost.expr, to_units=CE_index_units
+                        )
                     )
             else:
-                if pyunits.get_units(additional_chemicals_cost) == pyunits.dimensionless:
-                    self.additional_chemicals_cost = Expression(expr=additional_chemicals_cost * CE_index_units)
+                if (
+                    pyunits.get_units(additional_chemicals_cost)
+                    == pyunits.dimensionless
+                ):
+                    self.additional_chemicals_cost = Expression(
+                        expr=additional_chemicals_cost * CE_index_units
+                    )
                 else:
                     self.additional_chemicals_cost = Expression(
-                        expr=pyunits.convert(additional_chemicals_cost, to_units=CE_index_units)
+                        expr=pyunits.convert(
+                            additional_chemicals_cost, to_units=CE_index_units
+                        )
                     )
         else:
             self.additional_chemicals_cost = Expression(expr=0 * CE_index_units)
@@ -742,17 +756,25 @@ class QGESSCostingData(FlowsheetCostingBlockData):
         if additional_waste_cost is not None:
             if type(additional_waste_cost) in [Expression, ScalarExpression]:
                 if pyunits.get_units(additional_waste_cost) == pyunits.dimensionless:
-                    self.additional_waste_cost = Expression(expr=additional_waste_cost.expr * CE_index_units)
+                    self.additional_waste_cost = Expression(
+                        expr=additional_waste_cost.expr * CE_index_units
+                    )
                 else:
                     self.additional_waste_cost = Expression(
-                        expr=pyunits.convert(additional_waste_cost.expr, to_units=CE_index_units)
+                        expr=pyunits.convert(
+                            additional_waste_cost.expr, to_units=CE_index_units
+                        )
                     )
             else:
                 if pyunits.get_units(additional_waste_cost) == pyunits.dimensionless:
-                    self.additional_waste_cost = Expression(expr=additional_waste_cost * CE_index_units)
+                    self.additional_waste_cost = Expression(
+                        expr=additional_waste_cost * CE_index_units
+                    )
                 else:
                     self.additional_waste_cost = Expression(
-                        expr=pyunits.convert(additional_waste_cost, to_units=CE_index_units)
+                        expr=pyunits.convert(
+                            additional_waste_cost, to_units=CE_index_units
+                        )
                     )
         else:
             self.additional_waste_cost = Expression(expr=0 * CE_index_units)
@@ -1087,8 +1109,10 @@ class QGESSCostingData(FlowsheetCostingBlockData):
             if hasattr(self, "additional_waste_cost"):
                 var_dict["Total Variable Waste Cost [$MM/year]"] = value(
                     sum(
-                        self.variable_operating_costs[0, waste] for waste in self.waste_list
-                    ) + self.additional_waste_cost
+                        self.variable_operating_costs[0, waste]
+                        for waste in self.waste_list
+                    )
+                    + self.additional_waste_cost
                 )
 
             if hasattr(self, "additional_chemicals_cost"):
@@ -1096,7 +1120,8 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                     sum(
                         self.variable_operating_costs[0, chemical]
                         for chemical in self.chemicals_list
-                    ) + self.additional_chemicals_cost
+                    )
+                    + self.additional_chemicals_cost
                 )
 
             var_dict["General Plant Overhead Cost [$MM/year]"] = value(

--- a/src/prommis/uky/costing/ree_plant_capcost.py
+++ b/src/prommis/uky/costing/ree_plant_capcost.py
@@ -2465,14 +2465,10 @@ class QGESSCostingData(FlowsheetCostingBlockData):
             )
         if hasattr(b, "recovery_rate_per_year"):
             print(
-                "Rate of recovery: %.3f kg/hr REE recovered"
-                % value(b.recovery_rate_per_year)
-            )
-            print(
-                "Annual recovery: %.3f ton/year REE recovered"
+                "Annual rate of recovery: %.3f kg/year REE recovered"
                 % value(
                     pyunits.convert(
-                        b.recovery_rate_per_year, to_units=pyunits.ton / pyunits.year
+                        b.recovery_rate_per_year, to_units=pyunits.kg / pyunits.year
                     )
                 )
             )

--- a/src/prommis/uky/costing/ree_plant_capcost.py
+++ b/src/prommis/uky/costing/ree_plant_capcost.py
@@ -842,12 +842,6 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                             units=pyunits.get_units(recovery_rate_per_year),
                         )
                     recovery_units_factor = 1
-                # else:
-                #     if (
-                #         pyunits.get_units(self.recovery_rate_per_year)
-                #         == pyunits.dimensionless
-                #     ):
-                #         recovery_units_factor = pyunits.kg / pyunits.year
 
                 rec_rate_units = pyunits.get_units(self.recovery_rate_per_year)
 
@@ -1096,17 +1090,6 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                         self.variable_operating_costs[0, waste] for waste in self.waste_list
                     ) + self.additional_waste_cost
                 )
-            # else:
-            #     var_dict["Total Variable Waste Cost [$MM/year]"] = value(
-            #         sum(
-            #             self.variable_operating_costs[0, waste] for waste in self.waste_list
-            #         )
-            #     )
-
-            # if hasattr(self, "fuel"):
-            #     var_dict["Total Variable Fuel Cost [$MM/year]"] = value(
-            #         self.variable_operating_costs[0, self.fuel]
-            #     )
 
             if hasattr(self, "additional_chemicals_cost"):
                 var_dict["Total Variable Chemicals Cost [$MM/year]"] = value(
@@ -1115,13 +1098,6 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                         for chemical in self.chemicals_list
                     ) + self.additional_chemicals_cost
                 )
-            # else:
-            #     var_dict["Total Variable Chemicals Cost [$MM/year]"] = value(
-            #         sum(
-            #             self.variable_operating_costs[0, chemical]
-            #             for chemical in self.chemicals_list
-            #         )
-            #     )
 
             var_dict["General Plant Overhead Cost [$MM/year]"] = value(
                 self.plant_overhead_cost[0]

--- a/src/prommis/uky/costing/ree_plant_capcost.py
+++ b/src/prommis/uky/costing/ree_plant_capcost.py
@@ -842,12 +842,12 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                             units=pyunits.get_units(recovery_rate_per_year),
                         )
                     recovery_units_factor = 1
-                else:
-                    if (
-                        pyunits.get_units(self.recovery_rate_per_year)
-                        == pyunits.dimensionless
-                    ):
-                        recovery_units_factor = pyunits.kg / pyunits.year
+                # else:
+                #     if (
+                #         pyunits.get_units(self.recovery_rate_per_year)
+                #         == pyunits.dimensionless
+                #     ):
+                #         recovery_units_factor = pyunits.kg / pyunits.year
 
                 rec_rate_units = pyunits.get_units(self.recovery_rate_per_year)
 
@@ -1090,23 +1090,23 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                 self.variable_operating_costs[0, "power"]
             )
 
-            if hasattr(self, "waste_cost"):
+            if hasattr(self, "additional_waste_cost"):
                 var_dict["Total Variable Waste Cost [$MM/year]"] = value(
                     sum(
                         self.variable_operating_costs[0, waste] for waste in self.waste_list
                     ) + self.additional_waste_cost
                 )
-            else:
-                var_dict["Total Variable Waste Cost [$MM/year]"] = value(
-                    sum(
-                        self.variable_operating_costs[0, waste] for waste in self.waste_list
-                    )
-                )
+            # else:
+            #     var_dict["Total Variable Waste Cost [$MM/year]"] = value(
+            #         sum(
+            #             self.variable_operating_costs[0, waste] for waste in self.waste_list
+            #         )
+            #     )
 
-            if hasattr(self, "fuel"):
-                var_dict["Total Variable Fuel Cost [$MM/year]"] = value(
-                    self.variable_operating_costs[0, self.fuel]
-                )
+            # if hasattr(self, "fuel"):
+            #     var_dict["Total Variable Fuel Cost [$MM/year]"] = value(
+            #         self.variable_operating_costs[0, self.fuel]
+            #     )
 
             if hasattr(self, "additional_chemicals_cost"):
                 var_dict["Total Variable Chemicals Cost [$MM/year]"] = value(
@@ -1115,13 +1115,13 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                         for chemical in self.chemicals_list
                     ) + self.additional_chemicals_cost
                 )
-            else:
-                var_dict["Total Variable Chemicals Cost [$MM/year]"] = value(
-                    sum(
-                        self.variable_operating_costs[0, chemical]
-                        for chemical in self.chemicals_list
-                    )
-                )
+            # else:
+            #     var_dict["Total Variable Chemicals Cost [$MM/year]"] = value(
+            #         sum(
+            #             self.variable_operating_costs[0, chemical]
+            #             for chemical in self.chemicals_list
+            #         )
+            #     )
 
             var_dict["General Plant Overhead Cost [$MM/year]"] = value(
                 self.plant_overhead_cost[0]
@@ -1951,7 +1951,7 @@ class QGESSCostingData(FlowsheetCostingBlockData):
         # sum of fixed operating costs of membrane units
         @b.Constraint()
         def sum_watertap_fixed_cost(c):
-            if c.watertap_fixed_costs_list is None:
+            if not hasattr(c, "watertap_fixed_costs_list"):
                 return c.watertap_fixed_costs == 0
             else:
                 return c.watertap_fixed_costs == sum(b.watertap_fixed_costs_list)

--- a/src/prommis/uky/costing/tests/test_ree_costing.py
+++ b/src/prommis/uky/costing/tests/test_ree_costing.py
@@ -3342,8 +3342,12 @@ def test_REE_costing_variableOM_defaults():
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1441, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
     assert pyo.value(m.fs.costing.land_cost) == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(
+        0.0000, abs=1e-4
+    )
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(
+        0.0000, abs=1e-4
+    )
 
 
 @pytest.mark.component
@@ -3422,8 +3426,12 @@ def test_REE_costing_variableOM_steadystateflowsheet():
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1441, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
     assert pyo.value(m.fs.costing.land_cost) == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(
+        0.0000, abs=1e-4
+    )
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(
+        0.0000, abs=1e-4
+    )
 
 
 @pytest.mark.component
@@ -3501,7 +3509,9 @@ def test_REE_costing_chemicalscostExpression_withunits():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(
+        0.001, rel=1e-4
+    )
 
 
 @pytest.mark.component
@@ -3579,8 +3589,12 @@ def test_REE_costing_chemicalscostExpression_nounits():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.001, rel=1e-4)
-    assert pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(
+        0.001, rel=1e-4
+    )
+    assert (
+        pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+    )
 
 
 @pytest.mark.component
@@ -3659,8 +3673,12 @@ def test_REE_costing_chemicalscostnonExpression_withunits():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.001, rel=1e-4)
-    assert pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(
+        0.001, rel=1e-4
+    )
+    assert (
+        pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+    )
 
 
 @pytest.mark.component
@@ -3739,8 +3757,12 @@ def test_REE_costing_chemicalscostnonExpression_nounits():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.001, rel=1e-4)
-    assert pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(
+        0.001, rel=1e-4
+    )
+    assert (
+        pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+    )
 
 
 @pytest.mark.component
@@ -3818,7 +3840,9 @@ def test_REE_costing_wastecostExpression_withunits():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(
+        0.001, rel=1e-4
+    )
 
 
 @pytest.mark.component
@@ -3896,7 +3920,9 @@ def test_REE_costing_wastecostExpression_nounits():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(
+        0.001, rel=1e-4
+    )
     assert pyunits.get_units(m.fs.costing.additional_waste_cost) == pyunits.MUSD_2021
 
 
@@ -3976,7 +4002,9 @@ def test_REE_costing_wastecostnonExpression_withunits():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(
+        0.001, rel=1e-4
+    )
     assert pyunits.get_units(m.fs.costing.additional_waste_cost) == pyunits.MUSD_2021
 
 
@@ -4056,7 +4084,9 @@ def test_REE_costing_wastecostnonExpression_nounits():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
-    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(
+        0.001, rel=1e-4
+    )
     assert pyunits.get_units(m.fs.costing.additional_waste_cost) == pyunits.MUSD_2021
 
 

--- a/src/prommis/uky/costing/tests/test_ree_costing.py
+++ b/src/prommis/uky/costing/tests/test_ree_costing.py
@@ -2720,6 +2720,7 @@ def test_REE_costing_landcostnonExpression_withunits():
 
     # define land_cost
     m.fs.land_cost = pyo.Var(initialize=1e-3, units=pyunits.MUSD_2021)
+    m.fs.land_cost.fix()
 
     # defaults to fixed_OM=True, so explicitly set to False
     # defaults to variable_OM=False, so let that use the default
@@ -3302,6 +3303,9 @@ def test_REE_costing_variableOM_defaults():
     assert hasattr(m.fs.costing, "total_variable_OM_cost")
     assert hasattr(m.fs.costing, "plant_overhead_cost")
     assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "land_cost")
+    assert hasattr(m.fs.costing, "additional_chemicals_cost")
+    assert hasattr(m.fs.costing, "additional_waste_cost")
     assert not hasattr(m.fs.costing, "cost_of_recovery")
 
     # check some cost results
@@ -3313,6 +3317,643 @@ def test_REE_costing_variableOM_defaults():
     )
     assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1441, rel=1e-4)
     assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.land_cost) == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.0000, abs=1e-4)
+
+
+@pytest.mark.component
+def test_REE_costing_chemicalscostExpression_withunits():
+    m = pyo.ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=True, time_units=pyunits.s)
+    m.fs.costing = QGESSCosting()
+
+    # 1.3 is CS Jaw Crusher
+    CS_jaw_crusher_accounts = ["1.3"]
+    m.fs.CS_jaw_crusher = UnitModelBlock()
+    m.fs.CS_jaw_crusher.power = pyo.Var(initialize=589, units=pyunits.hp)
+    m.fs.CS_jaw_crusher.power.fix()
+    m.fs.CS_jaw_crusher.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+        costing_method=QGESSCostingData.get_REE_costing,
+        costing_method_arguments={
+            "cost_accounts": CS_jaw_crusher_accounts,
+            "scaled_param": m.fs.CS_jaw_crusher.power,
+            "source": 1,
+        },
+    )
+
+    m.fs.feed_input = pyo.Var(initialize=500, units=pyunits.ton / pyunits.hr)
+    m.fs.feed_input.fix()
+
+    m.fs.water = pyo.Var(m.fs.time, initialize=1000, units=pyunits.gallon / pyunits.hr)
+    m.fs.water.fix()
+
+    # define additional_chemicals_cost
+    m.fs.additional_chemicals_cost = pyo.Expression(expr=1e-3 * pyunits.MUSD_2021)
+
+    m.fs.costing.build_process_costs(
+        fixed_OM=True,
+        pure_product_output_rates={
+            "Sc2O3": 1.9 * pyunits.kg / pyunits.hr,
+        },
+        mixed_product_output_rates={
+            "Sc2O3": 0.00143 * pyunits.kg / pyunits.hr,
+        },
+        variable_OM=True,
+        feed_input=m.fs.feed_input,
+        resources=[
+            "water",
+        ],
+        rates=[
+            m.fs.water,
+        ],
+        additional_chemicals_cost=m.fs.additional_chemicals_cost,
+    )
+
+    QGESSCostingData.costing_initialization(m.fs.costing)
+    QGESSCostingData.initialize_fixed_OM_costs(m.fs.costing)
+    QGESSCostingData.initialize_variable_OM_costs(m.fs.costing)
+    solver = get_solver()
+    results = solver.solve(m, tee=True)
+    assert check_optimal_termination(results)
+    assert_units_consistent(m)
+
+    # check that some objects builts as expected
+    assert hasattr(m.fs.costing, "feed_input_rate")
+    assert hasattr(m.fs.costing, "total_fixed_OM_cost")
+    assert hasattr(m.fs.costing, "total_variable_OM_cost")
+    assert hasattr(m.fs.costing, "plant_overhead_cost")
+    assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "additional_chemicals_cost")
+    assert not hasattr(m.fs.costing, "cost_of_recovery")
+
+    # check some cost results
+    assert str(pyunits.get_units(m.fs.costing.feed_input_rate)) == "ton/h"
+    assert pyo.value(m.fs.costing.feed_input_rate) == pytest.approx(500.00, rel=1e-4)
+    assert m.fs.costing.total_fixed_OM_cost.value == pytest.approx(5.7207, rel=1e-4)
+    assert m.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+        1.1607, rel=1e-4
+    )
+    assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
+    assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.001, rel=1e-4)
+
+
+@pytest.mark.component
+def test_REE_costing_chemicalscostExpression_nounits():
+    m = pyo.ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=True, time_units=pyunits.s)
+    m.fs.costing = QGESSCosting()
+
+    # 1.3 is CS Jaw Crusher
+    CS_jaw_crusher_accounts = ["1.3"]
+    m.fs.CS_jaw_crusher = UnitModelBlock()
+    m.fs.CS_jaw_crusher.power = pyo.Var(initialize=589, units=pyunits.hp)
+    m.fs.CS_jaw_crusher.power.fix()
+    m.fs.CS_jaw_crusher.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+        costing_method=QGESSCostingData.get_REE_costing,
+        costing_method_arguments={
+            "cost_accounts": CS_jaw_crusher_accounts,
+            "scaled_param": m.fs.CS_jaw_crusher.power,
+            "source": 1,
+        },
+    )
+
+    m.fs.feed_input = pyo.Var(initialize=500, units=pyunits.ton / pyunits.hr)
+    m.fs.feed_input.fix()
+
+    m.fs.water = pyo.Var(m.fs.time, initialize=1000, units=pyunits.gallon / pyunits.hr)
+    m.fs.water.fix()
+
+    # define additional_chemicals_cost
+    m.fs.additional_chemicals_cost = pyo.Expression(expr=1e-3)
+
+    m.fs.costing.build_process_costs(
+        fixed_OM=True,
+        pure_product_output_rates={
+            "Sc2O3": 1.9 * pyunits.kg / pyunits.hr,
+        },
+        mixed_product_output_rates={
+            "Sc2O3": 0.00143 * pyunits.kg / pyunits.hr,
+        },
+        variable_OM=True,
+        feed_input=m.fs.feed_input,
+        resources=[
+            "water",
+        ],
+        rates=[
+            m.fs.water,
+        ],
+        additional_chemicals_cost=m.fs.additional_chemicals_cost,
+    )
+
+    QGESSCostingData.costing_initialization(m.fs.costing)
+    QGESSCostingData.initialize_fixed_OM_costs(m.fs.costing)
+    QGESSCostingData.initialize_variable_OM_costs(m.fs.costing)
+    solver = get_solver()
+    results = solver.solve(m, tee=True)
+    assert check_optimal_termination(results)
+    assert_units_consistent(m)
+
+    # check that some objects builts as expected
+    assert hasattr(m.fs.costing, "feed_input_rate")
+    assert hasattr(m.fs.costing, "total_fixed_OM_cost")
+    assert hasattr(m.fs.costing, "total_variable_OM_cost")
+    assert hasattr(m.fs.costing, "plant_overhead_cost")
+    assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "additional_chemicals_cost")
+    assert not hasattr(m.fs.costing, "cost_of_recovery")
+
+    # check some cost results
+    assert str(pyunits.get_units(m.fs.costing.feed_input_rate)) == "ton/h"
+    assert pyo.value(m.fs.costing.feed_input_rate) == pytest.approx(500.00, rel=1e-4)
+    assert m.fs.costing.total_fixed_OM_cost.value == pytest.approx(5.7207, rel=1e-4)
+    assert m.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+        1.1607, rel=1e-4
+    )
+    assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
+    assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+
+
+@pytest.mark.component
+def test_REE_costing_chemicalscostnonExpression_withunits():
+    m = pyo.ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=True, time_units=pyunits.s)
+    m.fs.costing = QGESSCosting()
+
+    # 1.3 is CS Jaw Crusher
+    CS_jaw_crusher_accounts = ["1.3"]
+    m.fs.CS_jaw_crusher = UnitModelBlock()
+    m.fs.CS_jaw_crusher.power = pyo.Var(initialize=589, units=pyunits.hp)
+    m.fs.CS_jaw_crusher.power.fix()
+    m.fs.CS_jaw_crusher.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+        costing_method=QGESSCostingData.get_REE_costing,
+        costing_method_arguments={
+            "cost_accounts": CS_jaw_crusher_accounts,
+            "scaled_param": m.fs.CS_jaw_crusher.power,
+            "source": 1,
+        },
+    )
+
+    m.fs.feed_input = pyo.Var(initialize=500, units=pyunits.ton / pyunits.hr)
+    m.fs.feed_input.fix()
+
+    m.fs.water = pyo.Var(m.fs.time, initialize=1000, units=pyunits.gallon / pyunits.hr)
+    m.fs.water.fix()
+
+    # define additional_chemicals_cost
+    m.fs.additional_chemicals_cost = pyo.Var(initialize=1e-3, units=pyunits.MUSD_2021)
+    m.fs.additional_chemicals_cost.fix()
+
+    m.fs.costing.build_process_costs(
+        fixed_OM=True,
+        pure_product_output_rates={
+            "Sc2O3": 1.9 * pyunits.kg / pyunits.hr,
+        },
+        mixed_product_output_rates={
+            "Sc2O3": 0.00143 * pyunits.kg / pyunits.hr,
+        },
+        variable_OM=True,
+        feed_input=m.fs.feed_input,
+        resources=[
+            "water",
+        ],
+        rates=[
+            m.fs.water,
+        ],
+        additional_chemicals_cost=m.fs.additional_chemicals_cost,
+    )
+
+    QGESSCostingData.costing_initialization(m.fs.costing)
+    QGESSCostingData.initialize_fixed_OM_costs(m.fs.costing)
+    QGESSCostingData.initialize_variable_OM_costs(m.fs.costing)
+    solver = get_solver()
+    results = solver.solve(m, tee=True)
+    assert check_optimal_termination(results)
+    assert_units_consistent(m)
+
+    # check that some objects builts as expected
+    assert hasattr(m.fs.costing, "feed_input_rate")
+    assert hasattr(m.fs.costing, "total_fixed_OM_cost")
+    assert hasattr(m.fs.costing, "total_variable_OM_cost")
+    assert hasattr(m.fs.costing, "plant_overhead_cost")
+    assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "additional_chemicals_cost")
+    assert not hasattr(m.fs.costing, "cost_of_recovery")
+
+    # check some cost results
+    assert str(pyunits.get_units(m.fs.costing.feed_input_rate)) == "ton/h"
+    assert pyo.value(m.fs.costing.feed_input_rate) == pytest.approx(500.00, rel=1e-4)
+    assert m.fs.costing.total_fixed_OM_cost.value == pytest.approx(5.7207, rel=1e-4)
+    assert m.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+        1.1607, rel=1e-4
+    )
+    assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
+    assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+
+
+@pytest.mark.component
+def test_REE_costing_chemicalscostnonExpression_nounits():
+    m = pyo.ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=True, time_units=pyunits.s)
+    m.fs.costing = QGESSCosting()
+
+    # 1.3 is CS Jaw Crusher
+    CS_jaw_crusher_accounts = ["1.3"]
+    m.fs.CS_jaw_crusher = UnitModelBlock()
+    m.fs.CS_jaw_crusher.power = pyo.Var(initialize=589, units=pyunits.hp)
+    m.fs.CS_jaw_crusher.power.fix()
+    m.fs.CS_jaw_crusher.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+        costing_method=QGESSCostingData.get_REE_costing,
+        costing_method_arguments={
+            "cost_accounts": CS_jaw_crusher_accounts,
+            "scaled_param": m.fs.CS_jaw_crusher.power,
+            "source": 1,
+        },
+    )
+
+    m.fs.feed_input = pyo.Var(initialize=500, units=pyunits.ton / pyunits.hr)
+    m.fs.feed_input.fix()
+
+    m.fs.water = pyo.Var(m.fs.time, initialize=1000, units=pyunits.gallon / pyunits.hr)
+    m.fs.water.fix()
+
+    # define additional_chemicals_cost
+    m.fs.additional_chemicals_cost = pyo.Var(initialize=1e-3)
+    m.fs.additional_chemicals_cost.fix()
+
+    m.fs.costing.build_process_costs(
+        fixed_OM=True,
+        pure_product_output_rates={
+            "Sc2O3": 1.9 * pyunits.kg / pyunits.hr,
+        },
+        mixed_product_output_rates={
+            "Sc2O3": 0.00143 * pyunits.kg / pyunits.hr,
+        },
+        variable_OM=True,
+        feed_input=m.fs.feed_input,
+        resources=[
+            "water",
+        ],
+        rates=[
+            m.fs.water,
+        ],
+        additional_chemicals_cost=m.fs.additional_chemicals_cost,
+    )
+
+    QGESSCostingData.costing_initialization(m.fs.costing)
+    QGESSCostingData.initialize_fixed_OM_costs(m.fs.costing)
+    QGESSCostingData.initialize_variable_OM_costs(m.fs.costing)
+    solver = get_solver()
+    results = solver.solve(m, tee=True)
+    assert check_optimal_termination(results)
+    assert_units_consistent(m)
+
+    # check that some objects builts as expected
+    assert hasattr(m.fs.costing, "feed_input_rate")
+    assert hasattr(m.fs.costing, "total_fixed_OM_cost")
+    assert hasattr(m.fs.costing, "total_variable_OM_cost")
+    assert hasattr(m.fs.costing, "plant_overhead_cost")
+    assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "additional_chemicals_cost")
+    assert not hasattr(m.fs.costing, "cost_of_recovery")
+
+    # check some cost results
+    assert str(pyunits.get_units(m.fs.costing.feed_input_rate)) == "ton/h"
+    assert pyo.value(m.fs.costing.feed_input_rate) == pytest.approx(500.00, rel=1e-4)
+    assert m.fs.costing.total_fixed_OM_cost.value == pytest.approx(5.7207, rel=1e-4)
+    assert m.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+        1.1607, rel=1e-4
+    )
+    assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
+    assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_chemicals_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyunits.get_units(m.fs.costing.additional_chemicals_cost) == pyunits.MUSD_2021
+
+
+@pytest.mark.component
+def test_REE_costing_wastecostExpression_withunits():
+    m = pyo.ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=True, time_units=pyunits.s)
+    m.fs.costing = QGESSCosting()
+
+    # 1.3 is CS Jaw Crusher
+    CS_jaw_crusher_accounts = ["1.3"]
+    m.fs.CS_jaw_crusher = UnitModelBlock()
+    m.fs.CS_jaw_crusher.power = pyo.Var(initialize=589, units=pyunits.hp)
+    m.fs.CS_jaw_crusher.power.fix()
+    m.fs.CS_jaw_crusher.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+        costing_method=QGESSCostingData.get_REE_costing,
+        costing_method_arguments={
+            "cost_accounts": CS_jaw_crusher_accounts,
+            "scaled_param": m.fs.CS_jaw_crusher.power,
+            "source": 1,
+        },
+    )
+
+    m.fs.feed_input = pyo.Var(initialize=500, units=pyunits.ton / pyunits.hr)
+    m.fs.feed_input.fix()
+
+    m.fs.water = pyo.Var(m.fs.time, initialize=1000, units=pyunits.gallon / pyunits.hr)
+    m.fs.water.fix()
+
+    # define additional_waste_cost
+    m.fs.additional_waste_cost = pyo.Expression(expr=1e-3 * pyunits.MUSD_2021)
+
+    m.fs.costing.build_process_costs(
+        fixed_OM=True,
+        pure_product_output_rates={
+            "Sc2O3": 1.9 * pyunits.kg / pyunits.hr,
+        },
+        mixed_product_output_rates={
+            "Sc2O3": 0.00143 * pyunits.kg / pyunits.hr,
+        },
+        variable_OM=True,
+        feed_input=m.fs.feed_input,
+        resources=[
+            "water",
+        ],
+        rates=[
+            m.fs.water,
+        ],
+        additional_waste_cost=m.fs.additional_waste_cost,
+    )
+
+    QGESSCostingData.costing_initialization(m.fs.costing)
+    QGESSCostingData.initialize_fixed_OM_costs(m.fs.costing)
+    QGESSCostingData.initialize_variable_OM_costs(m.fs.costing)
+    solver = get_solver()
+    results = solver.solve(m, tee=True)
+    assert check_optimal_termination(results)
+    assert_units_consistent(m)
+
+    # check that some objects builts as expected
+    assert hasattr(m.fs.costing, "feed_input_rate")
+    assert hasattr(m.fs.costing, "total_fixed_OM_cost")
+    assert hasattr(m.fs.costing, "total_variable_OM_cost")
+    assert hasattr(m.fs.costing, "plant_overhead_cost")
+    assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "additional_waste_cost")
+    assert not hasattr(m.fs.costing, "cost_of_recovery")
+
+    # check some cost results
+    assert str(pyunits.get_units(m.fs.costing.feed_input_rate)) == "ton/h"
+    assert pyo.value(m.fs.costing.feed_input_rate) == pytest.approx(500.00, rel=1e-4)
+    assert m.fs.costing.total_fixed_OM_cost.value == pytest.approx(5.7207, rel=1e-4)
+    assert m.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+        1.1607, rel=1e-4
+    )
+    assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
+    assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.001, rel=1e-4)
+
+
+@pytest.mark.component
+def test_REE_costing_wastecostExpression_nounits():
+    m = pyo.ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=True, time_units=pyunits.s)
+    m.fs.costing = QGESSCosting()
+
+    # 1.3 is CS Jaw Crusher
+    CS_jaw_crusher_accounts = ["1.3"]
+    m.fs.CS_jaw_crusher = UnitModelBlock()
+    m.fs.CS_jaw_crusher.power = pyo.Var(initialize=589, units=pyunits.hp)
+    m.fs.CS_jaw_crusher.power.fix()
+    m.fs.CS_jaw_crusher.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+        costing_method=QGESSCostingData.get_REE_costing,
+        costing_method_arguments={
+            "cost_accounts": CS_jaw_crusher_accounts,
+            "scaled_param": m.fs.CS_jaw_crusher.power,
+            "source": 1,
+        },
+    )
+
+    m.fs.feed_input = pyo.Var(initialize=500, units=pyunits.ton / pyunits.hr)
+    m.fs.feed_input.fix()
+
+    m.fs.water = pyo.Var(m.fs.time, initialize=1000, units=pyunits.gallon / pyunits.hr)
+    m.fs.water.fix()
+
+    # define additional_waste_cost
+    m.fs.additional_waste_cost = pyo.Expression(expr=1e-3)
+
+    m.fs.costing.build_process_costs(
+        fixed_OM=True,
+        pure_product_output_rates={
+            "Sc2O3": 1.9 * pyunits.kg / pyunits.hr,
+        },
+        mixed_product_output_rates={
+            "Sc2O3": 0.00143 * pyunits.kg / pyunits.hr,
+        },
+        variable_OM=True,
+        feed_input=m.fs.feed_input,
+        resources=[
+            "water",
+        ],
+        rates=[
+            m.fs.water,
+        ],
+        additional_waste_cost=m.fs.additional_waste_cost,
+    )
+
+    QGESSCostingData.costing_initialization(m.fs.costing)
+    QGESSCostingData.initialize_fixed_OM_costs(m.fs.costing)
+    QGESSCostingData.initialize_variable_OM_costs(m.fs.costing)
+    solver = get_solver()
+    results = solver.solve(m, tee=True)
+    assert check_optimal_termination(results)
+    assert_units_consistent(m)
+
+    # check that some objects builts as expected
+    assert hasattr(m.fs.costing, "feed_input_rate")
+    assert hasattr(m.fs.costing, "total_fixed_OM_cost")
+    assert hasattr(m.fs.costing, "total_variable_OM_cost")
+    assert hasattr(m.fs.costing, "plant_overhead_cost")
+    assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "additional_waste_cost")
+    assert not hasattr(m.fs.costing, "cost_of_recovery")
+
+    # check some cost results
+    assert str(pyunits.get_units(m.fs.costing.feed_input_rate)) == "ton/h"
+    assert pyo.value(m.fs.costing.feed_input_rate) == pytest.approx(500.00, rel=1e-4)
+    assert m.fs.costing.total_fixed_OM_cost.value == pytest.approx(5.7207, rel=1e-4)
+    assert m.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+        1.1607, rel=1e-4
+    )
+    assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
+    assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyunits.get_units(m.fs.costing.additional_waste_cost) == pyunits.MUSD_2021
+
+
+@pytest.mark.component
+def test_REE_costing_wastecostnonExpression_withunits():
+    m = pyo.ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=True, time_units=pyunits.s)
+    m.fs.costing = QGESSCosting()
+
+    # 1.3 is CS Jaw Crusher
+    CS_jaw_crusher_accounts = ["1.3"]
+    m.fs.CS_jaw_crusher = UnitModelBlock()
+    m.fs.CS_jaw_crusher.power = pyo.Var(initialize=589, units=pyunits.hp)
+    m.fs.CS_jaw_crusher.power.fix()
+    m.fs.CS_jaw_crusher.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+        costing_method=QGESSCostingData.get_REE_costing,
+        costing_method_arguments={
+            "cost_accounts": CS_jaw_crusher_accounts,
+            "scaled_param": m.fs.CS_jaw_crusher.power,
+            "source": 1,
+        },
+    )
+
+    m.fs.feed_input = pyo.Var(initialize=500, units=pyunits.ton / pyunits.hr)
+    m.fs.feed_input.fix()
+
+    m.fs.water = pyo.Var(m.fs.time, initialize=1000, units=pyunits.gallon / pyunits.hr)
+    m.fs.water.fix()
+
+    # define additional_waste_cost
+    m.fs.additional_waste_cost = pyo.Var(initialize=1e-3, units=pyunits.MUSD_2021)
+    m.fs.additional_waste_cost.fix()
+
+    m.fs.costing.build_process_costs(
+        fixed_OM=True,
+        pure_product_output_rates={
+            "Sc2O3": 1.9 * pyunits.kg / pyunits.hr,
+        },
+        mixed_product_output_rates={
+            "Sc2O3": 0.00143 * pyunits.kg / pyunits.hr,
+        },
+        variable_OM=True,
+        feed_input=m.fs.feed_input,
+        resources=[
+            "water",
+        ],
+        rates=[
+            m.fs.water,
+        ],
+        additional_waste_cost=m.fs.additional_waste_cost,
+    )
+
+    QGESSCostingData.costing_initialization(m.fs.costing)
+    QGESSCostingData.initialize_fixed_OM_costs(m.fs.costing)
+    QGESSCostingData.initialize_variable_OM_costs(m.fs.costing)
+    solver = get_solver()
+    results = solver.solve(m, tee=True)
+    assert check_optimal_termination(results)
+    assert_units_consistent(m)
+
+    # check that some objects builts as expected
+    assert hasattr(m.fs.costing, "feed_input_rate")
+    assert hasattr(m.fs.costing, "total_fixed_OM_cost")
+    assert hasattr(m.fs.costing, "total_variable_OM_cost")
+    assert hasattr(m.fs.costing, "plant_overhead_cost")
+    assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "additional_waste_cost")
+    assert not hasattr(m.fs.costing, "cost_of_recovery")
+
+    # check some cost results
+    assert str(pyunits.get_units(m.fs.costing.feed_input_rate)) == "ton/h"
+    assert pyo.value(m.fs.costing.feed_input_rate) == pytest.approx(500.00, rel=1e-4)
+    assert m.fs.costing.total_fixed_OM_cost.value == pytest.approx(5.7207, rel=1e-4)
+    assert m.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+        1.1607, rel=1e-4
+    )
+    assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
+    assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyunits.get_units(m.fs.costing.additional_waste_cost) == pyunits.MUSD_2021
+
+
+@pytest.mark.component
+def test_REE_costing_wastecostnonExpression_nounits():
+    m = pyo.ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=True, time_units=pyunits.s)
+    m.fs.costing = QGESSCosting()
+
+    # 1.3 is CS Jaw Crusher
+    CS_jaw_crusher_accounts = ["1.3"]
+    m.fs.CS_jaw_crusher = UnitModelBlock()
+    m.fs.CS_jaw_crusher.power = pyo.Var(initialize=589, units=pyunits.hp)
+    m.fs.CS_jaw_crusher.power.fix()
+    m.fs.CS_jaw_crusher.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+        costing_method=QGESSCostingData.get_REE_costing,
+        costing_method_arguments={
+            "cost_accounts": CS_jaw_crusher_accounts,
+            "scaled_param": m.fs.CS_jaw_crusher.power,
+            "source": 1,
+        },
+    )
+
+    m.fs.feed_input = pyo.Var(initialize=500, units=pyunits.ton / pyunits.hr)
+    m.fs.feed_input.fix()
+
+    m.fs.water = pyo.Var(m.fs.time, initialize=1000, units=pyunits.gallon / pyunits.hr)
+    m.fs.water.fix()
+
+    # define additional_waste_cost
+    m.fs.additional_waste_cost = pyo.Var(initialize=1e-3)
+    m.fs.additional_waste_cost.fix()
+
+    m.fs.costing.build_process_costs(
+        fixed_OM=True,
+        pure_product_output_rates={
+            "Sc2O3": 1.9 * pyunits.kg / pyunits.hr,
+        },
+        mixed_product_output_rates={
+            "Sc2O3": 0.00143 * pyunits.kg / pyunits.hr,
+        },
+        variable_OM=True,
+        feed_input=m.fs.feed_input,
+        resources=[
+            "water",
+        ],
+        rates=[
+            m.fs.water,
+        ],
+        additional_waste_cost=m.fs.additional_waste_cost,
+    )
+
+    QGESSCostingData.costing_initialization(m.fs.costing)
+    QGESSCostingData.initialize_fixed_OM_costs(m.fs.costing)
+    QGESSCostingData.initialize_variable_OM_costs(m.fs.costing)
+    solver = get_solver()
+    results = solver.solve(m, tee=True)
+    assert check_optimal_termination(results)
+    assert_units_consistent(m)
+
+    # check that some objects builts as expected
+    assert hasattr(m.fs.costing, "feed_input_rate")
+    assert hasattr(m.fs.costing, "total_fixed_OM_cost")
+    assert hasattr(m.fs.costing, "total_variable_OM_cost")
+    assert hasattr(m.fs.costing, "plant_overhead_cost")
+    assert hasattr(m.fs.costing, "other_variable_costs")
+    assert hasattr(m.fs.costing, "additional_waste_cost")
+    assert not hasattr(m.fs.costing, "cost_of_recovery")
+
+    # check some cost results
+    assert str(pyunits.get_units(m.fs.costing.feed_input_rate)) == "ton/h"
+    assert pyo.value(m.fs.costing.feed_input_rate) == pytest.approx(500.00, rel=1e-4)
+    assert m.fs.costing.total_fixed_OM_cost.value == pytest.approx(5.7207, rel=1e-4)
+    assert m.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+        1.1607, rel=1e-4
+    )
+    assert m.fs.costing.plant_overhead_cost[0].value == pytest.approx(1.1443, rel=1e-4)
+    assert m.fs.costing.other_variable_costs[0].value == pytest.approx(0.0000, abs=1e-4)
+    assert pyo.value(m.fs.costing.additional_waste_cost) == pytest.approx(0.001, rel=1e-4)
+    assert pyunits.get_units(m.fs.costing.additional_waste_cost) == pyunits.MUSD_2021
 
 
 @pytest.mark.component
@@ -4715,7 +5356,7 @@ def test_REE_costing_recovery_Nonewithtransportcost():
 
     with pytest.raises(
         Exception,
-        match="If a transport_cost_per_ton_product is not None, "
+        match="If transport_cost_per_ton_product is not None, "
         "recovery_rate_per_year cannot be None.",
     ):
         m.fs.costing.build_process_costs(


### PR DESCRIPTION
## Summary/Motivation:

Adds options for users to specify additional chemical costs or waste costs as expressions, just as they can specify land costs. Resources are costed as normal and additional costs are considered separate from resources passed as "chemicals" or "waste" via the list arguments. For example, a user can now cost resources for water, power and diluent where diluent is a chemical, and also pass an expression to calculate misc. chemical reagent costs.

Also updates tests for new options, and closes gaps in code coverage.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
