### PR TITLE
Clean up precipitator and documentation

### DIFF
--- a/src/prommis/precipitate/precipitate_liquid_properties.py
+++ b/src/prommis/precipitate/precipitate_liquid_properties.py
@@ -36,6 +36,24 @@ from idaes.core.util.misc import add_object_reference
 # Precipitate solution property package
 @declare_process_block_class("AqueousParameter")
 class AqueousParameterData(PhysicalParameterBlock):
+    """
+    Property package for aqueous solution generated in oxalate precipitator.
+
+    Includes the following components:
+
+    * Rare Earths: Sc, Y, La, Ce, Pr, Nd, Sm, Gd, Dy
+    * Impurities: Al, Ca, Fe
+
+    Assumes the equilibrium reaction has a fixed rate and fixed partition coefficients
+    based on:
+
+    Wang, Y., Ziemkiewicz, P., Noble, A., A Hybrid Experimental and Theoretical Approach
+    to Optimize Recovery of Rare Earth Elements from Acid Mine Drainage,
+    Minerals, 2022, 12. 236
+
+    self.split can be substituted by surrogate model
+    """
+
     def build(self):
         super().build()
 
@@ -163,6 +181,11 @@ class _AqueousStateBlock(StateBlock):
 
 @declare_process_block_class("AqueousStateBlock", block_class=_AqueousStateBlock)
 class AqueousStateBlockkData(StateBlockData):
+    """
+    State block for aqueous solution generated in oxalate precipitator.
+
+    """
+
     def build(self):
         super().build()
 

--- a/src/prommis/precipitate/precipitate_solids_properties.py
+++ b/src/prommis/precipitate/precipitate_solids_properties.py
@@ -11,7 +11,7 @@
 # for full copyright and license information.
 #################################################################################
 """
-Initial property package for West Kentucky No. 13 coal refuse.
+Preliminary property package for West Kentucky No. 13 coal refuse.
 
 Authors: Alejandro Garciadiego
 """
@@ -48,6 +48,23 @@ def _config_blk_build(blk):
 
 @declare_process_block_class("PrecipitateParameters")
 class PrecipitateParametersData(PhysicalParameterBlock):
+    """
+    Solid phase property package for oxalate precipitation.
+
+    Based on assay provided in:
+
+    RESEARCH PERFORMANCE FINAL REPORT, Pilot-Scale Testing of an Integrated
+    Circuit for the Extraction of Rare Earth Minerals and Elements from Coal
+    and Coal Byproducts Using Advanced Separation Technologies,
+    Honaker, R.Q., et al., DE-FE0027035
+
+    Includes the following components:
+    * Rare Earth Oxalates: "Al2(C2O4)3(s)", "Fe2(C2O4)3(s)", "Sc2(C2O4)3(s)",
+    "Y2(C2O4)3(s)", "La2(C2O4)3(s)", "Ce2(C2O4)3(s)", "Pr2(C2O4)3(s)",
+    "Nd2(C2O4)3(s)", "Sm2(C2O4)3(s)", "Gd2(C2O4)3(s)", "Dy2(C2O4)3(s)"
+
+    """
+
     CONFIG = PhysicalParameterBlock.CONFIG()
     _config_blk_build(CONFIG)
 
@@ -161,6 +178,10 @@ class _PrecipitateBlock(StateBlock):
 
 @declare_process_block_class("PrecipitateBlock", block_class=_PrecipitateBlock)
 class PrecipitateStateBlockData(StateBlockData):
+    """
+    State block for solid REE oxalate.
+    """
+
     def build(self):
         super().build()
 

--- a/src/prommis/precipitate/tests/test_precipitator.py
+++ b/src/prommis/precipitate/tests/test_precipitator.py
@@ -80,7 +80,7 @@ class TestPrec(object):
         m.fs.unit.aqueous_inlet.conc_mass_comp[0, "Gd"].fix(10)
         m.fs.unit.aqueous_inlet.conc_mass_comp[0, "Dy"].fix(10)
 
-        m.fs.unit.cv_precipitate.properties_in[0].temperature.fix(348.15)
+        m.fs.unit.cv_precipitate[0].temperature.fix(348.15)
 
         return m
 
@@ -106,9 +106,9 @@ class TestPrec(object):
         assert hasattr(prec.fs.unit, "mass_balance")
         assert hasattr(prec.fs.unit, "vol_balance")
 
-        assert number_variables(prec.fs.unit) == 98
-        assert number_total_constraints(prec.fs.unit) == 84
-        assert number_unused_variables(prec.fs.unit) == 0
+        assert number_variables(prec.fs.unit) == 86
+        assert number_total_constraints(prec.fs.unit) == 72
+        assert number_unused_variables(prec.fs.unit) == 1
 
     @pytest.mark.component
     def test_units(self, prec):

--- a/src/prommis/uky/uky_flowsheet.py
+++ b/src/prommis/uky/uky_flowsheet.py
@@ -565,12 +565,7 @@ def set_scaling(m):
     m.scaling_factor[m.fs.solex_cleaner.mscontactor.organic[0, 2].flow_vol] = 1e-2
     m.scaling_factor[m.fs.solex_cleaner.mscontactor.organic[0, 3].flow_vol] = 1e-2
 
-    m.scaling_factor[m.fs.precipitator.cv_precipitate.properties_in[0].temperature] = (
-        1e2
-    )
-    m.scaling_factor[m.fs.precipitator.cv_precipitate.properties_out[0].temperature] = (
-        1e-4
-    )
+    m.scaling_factor[m.fs.precipitator.cv_precipitate[0].temperature] = 1e2
 
     m.scaling_factor[m.fs.precipitator.cv_aqueous.properties_in[0].flow_vol] = 1e-2
     m.scaling_factor[m.fs.precipitator.cv_aqueous.properties_out[0].flow_vol] = 1e-2
@@ -755,7 +750,7 @@ def set_operating_conditions(m):
     m.fs.sep1.split_fraction[:, "recycle"].fix(0.9)
     m.fs.sep2.split_fraction[:, "recycle"].fix(0.9)
 
-    m.fs.precipitator.cv_precipitate.properties_in[0].temperature.fix(348.15 * units.K)
+    m.fs.precipitator.cv_precipitate[0].temperature.fix(348.15 * units.K)
 
     # Roaster gas feed
     m.fs.roaster.deltaP.fix(0)
@@ -797,8 +792,8 @@ def set_operating_conditions(m):
     m.fs.precipitator.cv_aqueous.properties_out[0].flow_vol
     m.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp
 
-    m.fs.precipitator.cv_precipitate.properties_out[0].temperature
-    m.fs.precipitator.cv_precipitate.properties_out[0].flow_mol_comp
+    m.fs.precipitator.cv_precipitate[0].temperature
+    m.fs.precipitator.cv_precipitate[0].flow_mol_comp
 
 
 def initialize_system(m):
@@ -904,9 +899,7 @@ def initialize_system(m):
 
     # Pass the tear_guess to the SD tool
     seq.set_guesses_for(m.fs.precipitator.cv_aqueous.properties_out[0], tear_guesses1)
-    seq.set_guesses_for(
-        m.fs.precipitator.cv_precipitate.properties_out[0], tear_guesses2
-    )
+    seq.set_guesses_for(m.fs.precipitator.cv_precipitate[0], tear_guesses2)
     seq.set_guesses_for(m.fs.leach.liquid_inlet, tear_guesses3)
     seq.set_guesses_for(m.fs.solex_rougher.mscontactor.aqueous_inlet, tear_guesses4)
 
@@ -960,14 +953,12 @@ def initialize_system(m):
                 # Fix feed states
                 m.fs.precipitator.cv_aqueous.properties_in[0].flow_vol.fix()
                 m.fs.precipitator.cv_aqueous.properties_in[0].conc_mass_comp.fix()
-                m.fs.precipitator.cv_precipitate.properties_in[0].flow_mol_comp.fix()
                 # Re-solve precipitator unit
                 solver = SolverFactory("ipopt")
                 solver.solve(m.fs.precipitator, tee=True)
                 # Unfix feed states
                 m.fs.precipitator.cv_aqueous.properties_in[0].flow_vol.unfix()
                 m.fs.precipitator.cv_aqueous.properties_in[0].conc_mass_comp.unfix()
-                m.fs.precipitator.cv_precipitate.properties_in[0].flow_mol_comp.unfix()
         else:
             print(f"Initializing {stream}")
             initializer2.initialize(stream)


### PR DESCRIPTION
## Addresses Issue: 
Adds documentation to preliminary precipitator model.


## Summary/Motivation:
- Precipitator had no documentation

## Changes proposed in this PR:
- Change cv_precipitate from ControlVolume0DBlock to state_block and need to fix an inexistent inlet for the precipitate phase
- Adds documentation for unit and property packages

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
