### PR TITLE
Enable rendering module contents in Sphinx autosummary docs via custom template

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,4 +15,5 @@ sphinx:
     suppress_warnings:
       # executablebooks/sphinx-external-toc#36
       - etoc.toctree
-    templates_path: _templates
+    templates_path:
+      - _templates

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,3 +15,4 @@ sphinx:
     suppress_warnings:
       # executablebooks/sphinx-external-toc#36
       - etoc.toctree
+    templates_path: _templates

--- a/docs/_templates/autosummary/module-with-contents.rst
+++ b/docs/_templates/autosummary/module-with-contents.rst
@@ -1,0 +1,5 @@
+{{ fullname }}
+{{ underline }}
+
+.. automodule:: {{ fullname }}
+    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,7 @@ Leaching
 
 .. autosummary::
    :toctree: _autosummary
+   :template: autosummary/module-with-contents.rst
 
    prommis.leaching.leach_train
    prommis.leaching.leach_reactions
@@ -17,6 +18,7 @@ Roasting
 
 .. autosummary::
    :toctree: _autosummary
+   :template: autosummary/module-with-contents.rst
 
    prommis.roasting.ree_feed_roaster
    prommis.roasting.ree_oxalate_roaster
@@ -26,6 +28,7 @@ Solvent Extraction
 
 .. autosummary::
    :toctree: _autosummary
+   :template: autosummary/module-with-contents.rst
 
    prommis.solvent_extraction.ree_aq_distribution
    prommis.solvent_extraction.ree_og_distribution
@@ -36,6 +39,7 @@ Precipitate
 
 .. autosummary::
    :toctree: _autosummary
+   :template: autosummary/module-with-contents.rst
    
    prommis.precipitate.precipitator
    prommis.precipitate.precipitate_liquid_properties
@@ -46,5 +50,6 @@ Flowsheets
 
 .. autosummary::
    :toctree: _autosummary
+   :template: autosummary/module-with-contents.rst
 
    prommis.uky.uky_flowsheet

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,8 @@ pylint==2.17.7
 astroid==2.15.8
 pytest==7.*
 pytest-cov
-jupyter-book==1.0.*
+jupyter-book==0.15.* ; python_version < '3.9'
+jupyter-book==1.0.* ; python_version >= '3.9'
 isort
 nbmake==1.4.6
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pylint==2.17.7
 astroid==2.15.8
 pytest==7.*
 pytest-cov
-jupyter-book==0.15.*
+jupyter-book==1.0.*
 isort
 nbmake==1.4.6
 


### PR DESCRIPTION
## Summary/Motivation:

- Currently, the docs pages generated by `:autosummary:` only show a summary of a module's contents/members, i.e. functions or classes defined therein
- `:autosummary:` can be configured so that the generated page also contains information for module contents; however, this requires using custom templates
- Specifying a custom template directory within Jupyter Book's `_config.yml` resulted in an error while building; this turned out to be caused by a bug in Jupyter Book which was fixed in the recently released v1.0

![image](https://github.com/prommis/prommis/assets/48035537/4428518a-16e7-4924-9039-3e532e03080e)
![image](https://github.com/prommis/prommis/assets/48035537/e5398566-956f-4e40-9fa9-8e18b9f4a681)

## Changes proposed in this PR:
- Add custom template to be used for `:autosummary:` directory for modules
- Update uses of `:autosummary:` (i.e. `docs/api.rst`) to enable said template
- Update Jupyter Book to 1.0 to avoid bug preventing us from using this functionality with previous versions
### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
