### PR TITLE
Update IDAES and WaterTAP requirements after IDAES 2.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ classifiers = [
 keywords = ["IDAES", "energy systems", "chemical engineering", "process modeling"]
 dynamic = ["version"]
 dependencies = [
-    "idaes-pse >= 2.5.0 @ git+https://github.com/IDAES/idaes-pse@main",
+    "idaes-pse==2.5.0",
     "pyomo >= 6.7.0",
 ]
 [project.optional-dependencies]
 watertap = [
     # TODO: update once watertap 1.0.0 is available
-    "watertap >= 1.0.dev0 @ git+https://github.com/watertap-org/watertap@main",
+    "watertap @ git+https://github.com/watertap-org/watertap@main",
 ]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dependencies = [
 ]
 [project.optional-dependencies]
 watertap = [
-    # TODO: update once 0.12.0 is available
-    "watertap >= 0.12.0",
+    # TODO: update once watertap 1.0.0 is available
+    "watertap >= 1.0.dev0 @ git+https://github.com/watertap-org/watertap@main",
 ]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 keywords = ["IDAES", "energy systems", "chemical engineering", "process modeling"]
 dynamic = ["version"]
 dependencies = [
-    "idaes-pse @ git+https://github.com/IDAES/idaes-pse@main",
+    "idaes-pse >= 2.5.0 @ git+https://github.com/IDAES/idaes-pse@main",
     "pyomo >= 6.7.0",
 ]
 [project.optional-dependencies]

--- a/src/prommis/nanofiltration/nf_brine.py
+++ b/src/prommis/nanofiltration/nf_brine.py
@@ -28,12 +28,12 @@ from pyomo.network import Arc
 
 import idaes.core.util.scaling as iscale
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import Feed, Product
 import idaes.logger as idaeslog
 
+from watertap.core.solvers import get_solver
 from watertap.property_models.multicomp_aq_sol_prop_pack import (
     ActivityCoefficientModel,
     DensityCalculation,

--- a/src/prommis/nanofiltration/nf_brine_plot.py
+++ b/src/prommis/nanofiltration/nf_brine_plot.py
@@ -29,13 +29,13 @@ from pyomo.network import Arc
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import Feed, Product
 
 import matplotlib.pyplot as plt
 import numpy as np
+from watertap.core.solvers import get_solver
 from watertap.property_models.multicomp_aq_sol_prop_pack import (
     ActivityCoefficientModel,
     DensityCalculation,

--- a/src/prommis/uky/costing/tests/test_ree_costing.py
+++ b/src/prommis/uky/costing/tests/test_ree_costing.py
@@ -57,6 +57,7 @@ if watertap_costing_available:
         PressureChangeType,
         ReverseOsmosis1D,
     )
+    from watertap.core.solvers import get_solver as get_watertap_solver
 
 
 def base_model():
@@ -1240,12 +1241,15 @@ class TestREECosting(object):
 
 class TestWaterTAPCosting(object):
     @pytest.fixture(scope="class")
-    def model(self):
+    def solver(self):
+        return get_watertap_solver()
+
+    @pytest.fixture(scope="class")
+    def model(self, solver):
         pytest.importorskip("watertap", reason="WaterTAP dependency not available")
 
         model = base_model()
         model.fs_membrane = FlowsheetBlock(dynamic=False)
-        solver = get_solver()
         # Nanofiltration
 
         model.fs_membrane.nf_properties = MCASParameterBlock(
@@ -1529,7 +1533,7 @@ class TestWaterTAPCosting(object):
         return model
 
     @pytest.mark.component
-    def test_REE_watertap_costing(self, model):
+    def test_REE_watertap_costing(self, model, solver):
         # full smoke test with all components, O&M costs, and extra costs included
         CE_index_year = "UKy_2019"
 
@@ -1744,7 +1748,6 @@ class TestWaterTAPCosting(object):
         QGESSCostingData.initialize_fixed_OM_costs(model.fs.costing)
         QGESSCostingData.initialize_variable_OM_costs(model.fs.costing)
 
-        solver = get_solver()
         results = solver.solve(model, tee=True)
         assert check_optimal_termination(results)
 

--- a/src/prommis/uky/costing/tests/test_ree_costing.py
+++ b/src/prommis/uky/costing/tests/test_ree_costing.py
@@ -1242,12 +1242,11 @@ class TestREECosting(object):
 class TestWaterTAPCosting(object):
     @pytest.fixture(scope="class")
     def solver(self):
+        pytest.importorskip("watertap", reason="WaterTAP dependency not available")
         return get_watertap_solver()
 
     @pytest.fixture(scope="class")
     def model(self, solver):
-        pytest.importorskip("watertap", reason="WaterTAP dependency not available")
-
         model = base_model()
         model.fs_membrane = FlowsheetBlock(dynamic=False)
         # Nanofiltration


### PR DESCRIPTION
## Addresses Issue: 


## Summary/Motivation:


## Changes proposed in this PR:
- Update WaterTAP requirement to `watertap-org/watertap:main` (from 0.12.0)
- Switch to using `watertap.core.solvers.get_solver()` where applicable, which resolves #52 (thanks @bpaul4 for pointing out this as the likely cause of the test failures we were seeing before making this change)

## Reviewer's checklist / merge requirements:
- [x] The head branch (i.e. the "source" of the changes) is not the `main` branch on the PR author's fork
- ~~[ ] Documentation~~ N/A
- ~~[ ] Tests~~ N/A
- ~~[ ] Diagnostic tests for models~~ N/A

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
