### PR TITLE
Precipitation calculation with isotherms

### DIFF
--- a/src/prommis/precipitate/precipitate_liquid_properties.py
+++ b/src/prommis/precipitate/precipitate_liquid_properties.py
@@ -10,7 +10,7 @@ Initial property package for precipitate.
 Authors: Alejandro Garciadiego
 """
 
-from pyomo.environ import Param, Set, Var, units
+from pyomo.environ import Param, Set, Var, units, exp
 
 import idaes.core.util.scaling as iscale
 from idaes.core import (
@@ -76,29 +76,88 @@ class AqueousParameterData(PhysicalParameterBlock):
         self.Gd = Component()
         self.Dy = Component()
 
-        # parameter based on pH 1.28
+        # parameter based on pH 1.5
         # TODO add surrogate model/equation
-        self.split = Param(
+        self.split = Var(
             self.component_list,
             units=units.kg / units.kg,
             initialize={
                 "H2O": 1e-20,
-                "Sc": 31.61,
-                "Y": 74.46,
-                "La": 51.51,
-                "Ce": 68.07,
-                "Pr": 78,
-                "Nd": 81.55,
-                "Sm": 87.35,
-                "Gd": 88.01,
-                "Dy": 87.16,
-                "Al": 0.9,
-                "Ca": 20.50,
-                "Fe": 2.44,
+                "Sc": 0.3161,
+                "Y": 0.7446,
+                "La": 0.5151,
+                "Ce": 0.6807,
+                "Pr": 0.78,
+                "Nd": 0.8155,
+                "Sm": 0.8735,
+                "Gd": 0.8801,
+                "Dy": 0.8716,
+                "Al": 0.009,
+                "Ca": 0.0001,
+                "Fe": 0.0244,
                 "H": 1e-20,
                 "Cl": 1e-20,
                 "HSO4": 1e-20,
                 "SO4": 1e-20,
+            },
+            bounds=(1e-30, 100),
+        )
+
+        self.acid_flow = Var(
+            units=units.dimensionless,
+            initialize=6.4,
+            bounds=(1e-6, 100),
+        )
+
+        # parameter based on pH 1.5
+        # TODO add surrogate model/equation
+        self.E_D = Param(
+            self.component_list,
+            units=units.dimensionless,
+            initialize={
+                "H2O": 100,
+                "Sc": 6.42030,
+                "Y": 4.551786,
+                "La": 4.3717,
+                "Ce": 1.18848,
+                "Pr": 2.09604,
+                "Nd": 1.01030,
+                "Sm": 2.296176,
+                "Gd": 3.07276,
+                "Dy": 4.8608,
+                "Al": 50,
+                "Ca": 14.49274,
+                "Fe": 8.659561,
+                "H": 100,
+                "Cl": 100,
+                "HSO4": 100,
+                "SO4": 100,
+            },
+        )
+
+        # parameter based on pH 1.5
+        # TODO add surrogate model/equation
+        self.N_D = Param(
+            self.component_list,
+            units=units.dimensionless,
+            initialize={
+                "H2O": 100,
+                "Sc": 6.42030,
+                "Y": 4.67403,
+                "La": 4.6340,
+                "Ce": 2.737238,
+                "Pr": 3.44364,
+                "Nd": 2.419137,
+                "Sm": 3.7201,
+                "Gd": 4.1995,
+                "Dy": 4.73106,
+                "Al": 0.9,
+                "Ca": 4.45302,
+                "Fe": 3.6495,
+                "H": 100,
+                "Cl": 100,
+                "HSO4": 100,
+                "SO4": 100,
             },
         )
 
@@ -145,6 +204,23 @@ class AqueousParameterData(PhysicalParameterBlock):
                 "HSO4",
                 "SO4",
                 "H2O",
+            ]
+        )
+
+        self.split_elements = Set(
+            initialize=[
+                "Al",
+                # "Ca",
+                "Fe",
+                "Sc",
+                "Y",
+                "La",
+                "Ce",
+                "Pr",
+                "Nd",
+                "Sm",
+                "Gd",
+                "Dy",
             ]
         )
 

--- a/src/prommis/precipitate/tests/test_precipitator.py
+++ b/src/prommis/precipitate/tests/test_precipitator.py
@@ -89,9 +89,11 @@ class TestPrec(object):
         m.fs.unit.aqueous_inlet.conc_mass_comp[0, "Cl"].fix(1e-9)
         m.fs.unit.aqueous_inlet.conc_mass_comp[0, "SO4"].fix(1e-9)
         m.fs.unit.aqueous_inlet.conc_mass_comp[0, "HSO4"].fix(1e-9)
-        m.fs.unit.aqueous_inlet.conc_mass_comp[0, "H2O"].fix(1000000)
+        m.fs.unit.aqueous_inlet.conc_mass_comp[0, "H2O"].fix(100000)
 
         m.fs.unit.cv_precipitate[0].temperature.fix(348.15)
+
+        m.fs.properties_aq.acid_flow.fix(6.4)
 
         return m
 
@@ -118,7 +120,7 @@ class TestPrec(object):
         assert hasattr(prec.fs.unit, "vol_balance")
 
         assert number_variables(prec.fs.unit) == 117
-        assert number_total_constraints(prec.fs.unit) == 98
+        assert number_total_constraints(prec.fs.unit) == 115
         assert number_unused_variables(prec.fs.unit) == 1
 
     @pytest.mark.component
@@ -155,8 +157,13 @@ class TestPrec(object):
     @pytest.mark.component
     def test_solve(self, prec):
         solver = get_solver()
-        results = solver.solve(prec)
+        results = solver.solve(prec,tee=True)
         assert_optimal_termination(results)
+        prec.display()
+        dt = DiagnosticsToolbox(model=prec)
+        dt.report_numerical_issues()
+        dt.display_constraints_with_large_residuals()
+     
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -165,76 +172,76 @@ class TestPrec(object):
         assert pytest.approx(100, abs=1e-0) == value(
             prec.fs.unit.aqueous_outlet.flow_vol[0]
         )
-        assert pytest.approx(9.91, abs=1e-3) == value(
+        assert pytest.approx(9.982, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Al"]
         )
-        assert pytest.approx(7.95, abs=1e-3) == value(
+        assert pytest.approx(10, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Ca"]
         )
-        assert pytest.approx(3.193, abs=1e-3) == value(
+        assert pytest.approx(0.099, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Ce"]
         )
-        assert pytest.approx(1.284, abs=1e-3) == value(
+        assert pytest.approx(2.3824, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Dy"]
         )
-        assert pytest.approx(9.756, abs=1e-3) == value(
+        assert pytest.approx(9.5093, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Fe"]
         )
-        assert pytest.approx(1.199, abs=1e-3) == value(
+        assert pytest.approx(0.4486, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Gd"]
         )
-        assert pytest.approx(4.849, rel=1e-3) == value(
+        assert pytest.approx(1.5715, rel=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "La"]
         )
-        assert pytest.approx(1.845, abs=1e-3) == value(
+        assert pytest.approx(0.1142, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Nd"]
         )
-        assert pytest.approx(2.2, abs=1e-3) == value(
+        assert pytest.approx(0.2118, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Pr"]
         )
-        assert pytest.approx(6.839, abs=1e-3) == value(
+        assert pytest.approx(6.395, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Sc"]
         )
-        assert pytest.approx(1.265, abs=1e-3) == value(
+        assert pytest.approx(0.2183, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Sm"]
         )
-        assert pytest.approx(2.554, abs=1e-3) == value(
+        assert pytest.approx(1.8401, abs=1e-3) == value(
             prec.fs.unit.aqueous_outlet.conc_mass_comp[0, "Y"]
         )
-        assert pytest.approx(0.00016678, abs=1e-6) == value(
+        assert pytest.approx(3.20213e-05, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Al2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.0051150, abs=1e-6) == value(
+        assert pytest.approx(0.00, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Ca(C2O4)(s)"]
         )
-        assert pytest.approx(0.002429, abs=1e-6) == value(
+        assert pytest.approx(0.003533, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Ce2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.002682, abs=1e-6) == value(
+        assert pytest.approx(0.002343, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Dy2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.0002189, abs=1e-6) == value(
+        assert pytest.approx(0.0004392, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Fe2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.002799, abs=1e-6) == value(
+        assert pytest.approx(0.003036, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Gd2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.001854, abs=1e-6) == value(
+        assert pytest.approx(0.003033, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "La2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.0028268, abs=1e-6) == value(
+        assert pytest.approx(0.003426, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Nd2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.0027677, abs=1e-6) == value(
+        assert pytest.approx(0.0034732, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Pr2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.003517, abs=1e-6) == value(
+        assert pytest.approx(0.004009, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Sc2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.0029047, abs=1e-6) == value(
+        assert pytest.approx(0.003252, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Sm2(C2O4)3(s)"]
         )
-        assert pytest.approx(0.004188, abs=1e-6) == value(
+        assert pytest.approx(0.004589, abs=1e-6) == value(
             prec.fs.unit.precipitate_outlet.flow_mol_comp[0, "Y2(C2O4)3(s)"]
         )
         assert pytest.approx(348.15, abs=1e-3) == value(

--- a/src/prommis/uky/tests/test_uky_flowsheet.py
+++ b/src/prommis/uky/tests/test_uky_flowsheet.py
@@ -281,7 +281,7 @@ def test_solution(system_frame):
         3999.81895, 1e-4
     )
     assert model.fs.leach.liquid_outlet.conc_mass_comp[0, "La"].value == pytest.approx(
-        0.9865420, 1e-4
+        0.985535, 1e-4
     )
     assert model.fs.leach.liquid_outlet.conc_mass_comp[0, "Nd"].value == pytest.approx(
         0.94624, 1e-4
@@ -322,7 +322,7 @@ def test_solution(system_frame):
     ].value == pytest.approx(3.3573517e-5, 1e-4)
     assert model.fs.solex_rougher_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "La"
-    ].value == pytest.approx(0.00010512, 1e-4)
+    ].value == pytest.approx(0.00010469, 1e-4)
     assert model.fs.solex_rougher_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Nd"
     ].value == pytest.approx(0.00016566, 1e-4)
@@ -373,7 +373,7 @@ def test_solution(system_frame):
     ].value == pytest.approx(925.263005, 1e-4)
     assert model.fs.solex_rougher_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "La"
-    ].value == pytest.approx(2897.036916, 1e-4)
+    ].value == pytest.approx(2885.457709, 1e-4)
     assert model.fs.solex_rougher_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Nd"
     ].value == pytest.approx(4565.36775, 1e-4)
@@ -395,175 +395,175 @@ def test_solution(system_frame):
     ].value == pytest.approx(62.010, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Al"
-    ].value == pytest.approx(7.05737918e-9, 1e-4)
+    ].value == pytest.approx(7.06097232e-9, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Ca"
-    ].value == pytest.approx(1.51668539e-8, 1e-4)
+    ].value == pytest.approx(1.53922812e-8, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Ce"
-    ].value == pytest.approx(1.9068033e-6, 1e-4)
+    ].value == pytest.approx(1.5328127e-6, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Dy"
-    ].value == pytest.approx(4.35634416e-8, 1e-4)
+    ].value == pytest.approx(4.71103985e-8, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Fe"
-    ].value == pytest.approx(9.211715e-7, 1e-4)
+    ].value == pytest.approx(9.20253444e-7, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Gd"
-    ].value == pytest.approx(1.8157884e-7, 1e-4)
+    ].value == pytest.approx(1.727454e-7, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "La"
-    ].value == pytest.approx(7.402615e-7, 1e-4)
+    ].value == pytest.approx(5.711929e-7, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Nd"
-    ].value == pytest.approx(9.371941e-7, 1e-4)
+    ].value == pytest.approx(8.3426636e-7, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Pr"
-    ].value == pytest.approx(2.154441e-7, 1e-4)
+    ].value == pytest.approx(1.88093689e-7, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Sc"
-    ].value == pytest.approx(0.4212117, 1e-4)
+    ].value == pytest.approx(0.416941, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Sm"
-    ].value == pytest.approx(9.242277e-8, 1e-4)
+    ].value == pytest.approx(8.6243406e-8, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.organic_outlet.conc_mass_comp[
         0, "Y"
-    ].value == pytest.approx(1.2989422e-7, 1e-4)
+    ].value == pytest.approx(1.2328611e-7, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.flow_vol[
         0
     ].value == pytest.approx(9, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Al"
-    ].value == pytest.approx(0.389002, 1e-4)
+    ].value == pytest.approx(0.389200, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Ca"
-    ].value == pytest.approx(0.8359969, 1e-4)
+    ].value == pytest.approx(0.8484224, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Ce"
-    ].value == pytest.approx(105.10298449, 1e-4)
+    ].value == pytest.approx(84.48862787, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Dy"
-    ].value == pytest.approx(2.4012161, 1e-4)
+    ].value == pytest.approx(2.5967248, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Fe"
-    ].value == pytest.approx(0.0507687, 1e-4)
+    ].value == pytest.approx(0.0507180, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Gd"
-    ].value == pytest.approx(10.008624, 1e-4)
+    ].value == pytest.approx(9.5217255, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "La"
-    ].value == pytest.approx(40.803207, 1e-4)
+    ].value == pytest.approx(31.484149, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Nd"
-    ].value == pytest.approx(51.65813, 1e-4)
+    ].value == pytest.approx(45.984756, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Pr"
-    ].value == pytest.approx(11.8752795, 1e-4)
+    ].value == pytest.approx(10.3677228, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Sc"
-    ].value == pytest.approx(0.1346149, 1e-4)
+    ].value == pytest.approx(0.13325004, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Sm"
-    ].value == pytest.approx(5.094342, 1e-4)
+    ].value == pytest.approx(4.753735, 1e-4)
     assert model.fs.solex_cleaner_strip.mscontactor.aqueous_outlet.conc_mass_comp[
         0, "Y"
-    ].value == pytest.approx(7.15976825, 1e-4)
+    ].value == pytest.approx(6.7955297, 1e-4)
 
     assert model.fs.precipitator.cv_aqueous.properties_out[
         0
     ].flow_vol.value == pytest.approx(9, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Al"
-    ].value == pytest.approx(0.3855012, 1e-4)
+    ].value == pytest.approx(0.3885282, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Ca"
-    ].value == pytest.approx(0.66461753, 1e-4)
+    ].value == pytest.approx(0.8484224, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Ce"
-    ].value == pytest.approx(33.55938, 1e-4)
+    ].value == pytest.approx(0.837914, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Dy"
-    ].value == pytest.approx(0.30831, 1e-4)
+    ].value == pytest.approx(0.61864, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Fe"
-    ].value == pytest.approx(0.049530, 1e-4)
+    ].value == pytest.approx(0.0482296, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Gd"
-    ].value == pytest.approx(1.20003, 1e-4)
+    ].value == pytest.approx(0.4271792, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "La"
-    ].value == pytest.approx(19.78548, 1e-4)
+    ].value == pytest.approx(4.947998, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Nd"
-    ].value == pytest.approx(9.530926, 1e-4)
+    ].value == pytest.approx(0.525564, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Pr"
-    ].value == pytest.approx(2.61256, 1e-4)
+    ].value == pytest.approx(0.219600, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Sc"
-    ].value == pytest.approx(0.0920631, 1e-4)
+    ].value == pytest.approx(0.085226, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Sm"
-    ].value == pytest.approx(0.644434, 1e-4)
+    ].value == pytest.approx(0.103790, 1e-4)
     assert model.fs.precipitator.cv_aqueous.properties_out[0].conc_mass_comp[
         "Y"
-    ].value == pytest.approx(1.8286048, 1e-4)
+    ].value == pytest.approx(1.2504487, 1e-4)
 
     assert model.fs.precipitator.precipitate_outlet.temperature[
         0
     ].value == pytest.approx(348.15, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Al2(C2O4)3(s)"
-    ].value == pytest.approx(5.838925e-7, 1e-4)
+    ].value == pytest.approx(1.121647e-7, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Ce2(C2O4)3(s)"
-    ].value == pytest.approx(0.00229770, 1e-4)
+    ].value == pytest.approx(0.0026865, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Dy2(C2O4)3(s)"
-    ].value == pytest.approx(5.7957229e-5, 1e-4)
+    ].value == pytest.approx(5.4777516e-5, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Fe2(C2O4)3(s)"
-    ].value == pytest.approx(9.981925e-8, 1e-4)
+    ].value == pytest.approx(2.0051337e-7, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Gd2(C2O4)3(s)"
-    ].value == pytest.approx(0.0002520741, 1e-4)
+    ].value == pytest.approx(0.0002602572, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "La2(C2O4)3(s)"
-    ].value == pytest.approx(6.80896e-4, 1e-4)
+    ].value == pytest.approx(8.59671e-4, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Nd2(C2O4)3(s)"
-    ].value == pytest.approx(1.31427e-3, 1e-4)
+    ].value == pytest.approx(1.41821e-3, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Pr2(C2O4)3(s)"
-    ].value == pytest.approx(2.958e-4, 1e-4)
+    ].value == pytest.approx(3.24090e-4, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Sc2(C2O4)3(s)"
-    ].value == pytest.approx(4.260289e-6, 1e-4)
+    ].value == pytest.approx(4.808103e-6, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Sm2(C2O4)3(s)"
-    ].value == pytest.approx(1.33178e-4, 1e-4)
+    ].value == pytest.approx(1.39164e-4, 1e-4)
     assert model.fs.precipitator.precipitate_outlet.flow_mol_comp[
         0, "Y2(C2O4)3(s)"
-    ].value == pytest.approx(2.6984e-4, 1e-4)
+    ].value == pytest.approx(2.8066e-4, 1e-4)
 
     assert model.fs.roaster.gas_outlet.flow_mol[0].value == pytest.approx(
-        0.0085064, 1e-4
+        0.0085092, 1e-4
     )
     assert model.fs.roaster.gas_outlet.temperature[0].value == pytest.approx(
         873.15, 1e-4
     )
     assert model.fs.roaster.gas_outlet.pressure[0].value == pytest.approx(101325, 1e-4)
     assert model.fs.roaster.gas_outlet.mole_frac_comp[0, "CO2"].value == pytest.approx(
-        0.04061137, 1e-4
+        0.04073887, 1e-4
     )
     assert model.fs.roaster.gas_outlet.mole_frac_comp[0, "H2O"].value == pytest.approx(
-        0.173358, 1e-4
+        0.173534, 1e-4
     )
     assert model.fs.roaster.gas_outlet.mole_frac_comp[0, "N2"].value == pytest.approx(
-        0.683643, 1e-4
+        0.683409, 1e-4
     )
     assert model.fs.roaster.gas_outlet.mole_frac_comp[0, "O2"].value == pytest.approx(
-        0.102388, 1e-4
+        0.102317, 1e-4
     )
 
     assert model.fs.leach_mixer.outlet.flow_vol[0].value == pytest.approx(
@@ -803,7 +803,7 @@ def test_costing_solution(system_frame):
     )
     assert value(model.fs.costing.land_cost) == pytest.approx(6.1234e-5, rel=1e-4)
     assert model.fs.costing.total_sales_revenue.value == pytest.approx(
-        0.00018136, rel=1e-4
+        0.00019373, rel=1e-4
     )
 
 

--- a/src/prommis/uky/uky_flowsheet.py
+++ b/src/prommis/uky/uky_flowsheet.py
@@ -1482,6 +1482,7 @@ def set_operating_conditions(m):
     m.fs.sl_sep2.liquid_recovery.fix(0.7)
 
     m.fs.precipitator.cv_precipitate[0].temperature.fix(348.15 * units.K)
+    m.fs.properties_aq.acid_flow.fix(6.4)
 
     m.fs.precip_sep.split_fraction[:, "recycle"].fix(0.9)
 


### PR DESCRIPTION
## Addresses Issue: 
Lack of prediction from previous precipitation data

## Summary/Motivation:
Precipitation requires function to calculate precipitation based on acid dosage

## Changes proposed in this PR:
-Adds isotherm form calculation for oxalate precipitation based on acid dosage
-Data based on Visual Minteq

## Reviewer's checklist / merge requirements:
- [ ] The head branch (i.e. the "source" of the changes) is not the `main` branch on the PR author's fork
- [ ] Documentation
- [ ] Tests
- [ ] Diagnostic tests for models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
