### PR TITLE
Comment Out Checks For WaterTAP Variable Operating Costs

### DIFF
--- a/src/prommis/uky/costing/ree_plant_capcost.py
+++ b/src/prommis/uky/costing/ree_plant_capcost.py
@@ -2294,14 +2294,15 @@ class QGESSCostingData(FlowsheetCostingBlockData):
         # assume the user is not using this
         b.other_variable_costs.fix(0)
 
+        # TODO commented as no WaterTAP models currently use this, may change in the future
         # variable for user to assign watertap variable costs to,
         # constraint sets to sum of list, which is 0 for empty list
-        b.watertap_variable_costs = Var(
-            initialize=0,
-            bounds=(0, None),
-            doc="Watertap variable costs",
-            units=CE_index_units / pyunits.year,
-        )
+        # b.watertap_variable_costs = Var(
+        #     initialize=0,
+        #     bounds=(0, None),
+        #     doc="Watertap variable costs",
+        #     units=CE_index_units / pyunits.year,
+        # )
 
         # variable for user to assign custom variable costs to,
         # constraint sets to sum of list, which is 0 for empty list
@@ -2339,13 +2340,14 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                 )
             )
 
+        # TODO commented as no WaterTAP models currently use this, may change in the future
         # sum of variable operating costs of watertap units
-        @b.Constraint()
-        def sum_watertap_variable_costs(c):
-            if not hasattr(c, "watertap_variable_costs_list"):
-                return c.watertap_variable_costs == 0
-            else:
-                return c.watertap_variable_costs == sum(b.watertap_variable_costs_list)
+        # @b.Constraint()
+        # def sum_watertap_variable_costs(c):
+        #     if not hasattr(c, "watertap_variable_costs_list"):
+        #         return c.watertap_variable_costs == 0
+        #     else:
+        #         return c.watertap_variable_costs == sum(b.watertap_variable_costs_list)
 
         # sum of variable operating costs of custom units
         @b.Constraint()
@@ -2382,7 +2384,8 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                     )
                     + c.additional_chemicals_cost / pyunits.year
                     + c.additional_waste_cost / pyunits.year
-                    + c.watertap_variable_costs
+                    # TODO commented as no WaterTAP models currently use this, may change in the future
+                    # + c.watertap_variable_costs
                     + c.custom_variable_costs
                 )
 
@@ -2402,7 +2405,8 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                     )
                     + c.additional_chemicals_cost / pyunits.year
                     + c.additional_waste_cost / pyunits.year
-                    + c.watertap_variable_costs
+                    # TODO commented as no WaterTAP models currently use this, may change in the future
+                    # + c.watertap_variable_costs
                     + c.custom_variable_costs
                 )
 
@@ -2416,7 +2420,8 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                 + c.land_cost / pyunits.year
                 + c.additional_chemicals_cost / pyunits.year
                 + c.additional_waste_cost / pyunits.year
-                + c.watertap_variable_costs
+                # TODO commented as no WaterTAP models currently use this, may change in the future
+                # + c.watertap_variable_costs
                 + c.custom_variable_costs
             )
 
@@ -2567,7 +2572,8 @@ class QGESSCostingData(FlowsheetCostingBlockData):
 
         BEC_list = []
         b.watertap_fixed_costs_list = []
-        b.watertap_variable_costs_list = []
+        # TODO commented as no WaterTAP models currently use this, may change in the future
+        # b.watertap_variable_costs_list = []
         b.custom_fixed_costs_list = []
         b.custom_variable_costs_list = []
 
@@ -2619,13 +2625,14 @@ class QGESSCostingData(FlowsheetCostingBlockData):
                             to_units=CE_index_units / pyunits.year,
                         )
                     )
-                if hasattr(w.costing, "variable_operating_cost"):
-                    b.watertap_variable_costs_list.append(
-                        pyunits.convert(
-                            w.costing.variable_operating_cost,
-                            to_units=CE_index_units / pyunits.year,
-                        )
-                    )
+                # # TODO commented as no WaterTAP models currently use this, may change in the future
+                # if hasattr(w.costing, "variable_operating_cost"):
+                #     b.watertap_variable_costs_list.append(
+                #         pyunits.convert(
+                #             w.costing.variable_operating_cost,
+                #             to_units=CE_index_units / pyunits.year,
+                #         )
+                #     )
 
         b.total_BEC = Var(
             initialize=100,

--- a/src/prommis/uky/costing/tests/test_ree_costing.py
+++ b/src/prommis/uky/costing/tests/test_ree_costing.py
@@ -2053,16 +2053,17 @@ class TestWaterTAPCosting(object):
             12.17825, rel=1e-4
         )
 
-    @pytest.mark.component
-    def test_REE_watertap_costing_variableOPEX(self, model):
+    # TODO commented as no WaterTAP models currently use this, may change in the future
+    # @pytest.mark.component
+    # def test_REE_watertap_costing_variableOPEX(self, model):
 
-        assert model.fs.costing.watertap_variable_costs.value == pytest.approx(
-            0, abs=1e-4
-        )  # TODO add a WaterTAP example that uses variable operating costs
+    #     assert model.fs.costing.watertap_variable_costs.value == pytest.approx(
+    #         0, abs=1e-4
+    #     )
 
-        assert model.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
-            533.10082, rel=1e-4
-        )
+    #     assert model.fs.costing.total_variable_OM_cost[0].value == pytest.approx(
+    #         533.10082, rel=1e-4
+    #     )
 
 
 class TestCustomCosting(object):


### PR DESCRIPTION
## Addresses Issue: #109 


## Summary/Motivation:
All WaterTAP models now use fixed operating costs, and the check for variable operating cost variables in PrOMMiS is unnecessary.

## Changes proposed in this PR:
- Comments out lines related to variable operating costs in WaterTAP cost models
- May be uncommented in the future if and when WaterTAP models are developed containing variable operating costs

## Reviewer's checklist / merge requirements:
- [ ] The head branch (i.e. the "source" of the changes) is not the `main` branch on the PR author's fork
- [ ] Documentation
- [ ] Tests
- [ ] Diagnostic tests for models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
