### PR TITLE
Update Inlet H2O Conc in UKy Flowsheet

### DIFF
--- a/src/prommis/leaching/leaching.json
+++ b/src/prommis/leaching/leaching.json
@@ -1,12 +1,12 @@
 {
   "__metadata__": {
     "format_version": 4,
-    "date": "2025-06-26",
-    "time": "17:06:22.245014",
+    "date": "2025-08-04",
+    "time": "14:19:45.933588",
     "other": {},
     "__performance__": {
-      "n_components": 599,
-      "etime_make_dict": 0.0029718875885009766
+      "n_components": 613,
+      "etime_make_dict": 0.00208282470703125
     }
   },
   "unknown": {
@@ -255,142 +255,159 @@
                               }
                             }
                           },
+                          "H2C2O4": {
+                            "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
+                            "__id__": 42,
+                            "active": true,
+                            "data": {
+                              "None": {
+                                "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
+                                "__id__": 43,
+                                "active": true
+                              }
+                            }
+                          },
                           "mw": {
                             "__type__": "<class 'pyomo.core.base.param.IndexedParam'>",
-                            "__id__": 42,
+                            "__id__": 44,
                             "_mutable": true,
                             "data": {
                               "'H2O'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 43,
+                                "__id__": 45,
                                 "value": 0.018
                               },
                               "'H'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 44,
+                                "__id__": 46,
                                 "value": 0.001
                               },
                               "'HSO4'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 45,
+                                "__id__": 47,
                                 "value": 0.097
                               },
                               "'SO4'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 46,
+                                "__id__": 48,
                                 "value": 0.096
                               },
                               "'Cl'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 47,
+                                "__id__": 49,
                                 "value": 0.035453
                               },
                               "'Sc'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 48,
+                                "__id__": 50,
                                 "value": 0.044946
                               },
                               "'Y'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 49,
+                                "__id__": 51,
                                 "value": 0.088905
                               },
                               "'La'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 50,
+                                "__id__": 52,
                                 "value": 0.138905
                               },
                               "'Ce'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 51,
+                                "__id__": 53,
                                 "value": 0.140116
                               },
                               "'Pr'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 52,
+                                "__id__": 54,
                                 "value": 0.140907
                               },
                               "'Nd'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 53,
+                                "__id__": 55,
                                 "value": 0.144242
                               },
                               "'Sm'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 54,
+                                "__id__": 56,
                                 "value": 0.15036
                               },
                               "'Gd'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 55,
+                                "__id__": 57,
                                 "value": 0.15725
                               },
                               "'Dy'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 56,
+                                "__id__": 58,
                                 "value": 0.1625
                               },
                               "'Al'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 57,
+                                "__id__": 59,
                                 "value": 0.026982
                               },
                               "'Ca'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 58,
+                                "__id__": 60,
                                 "value": 0.040078
                               },
                               "'Fe'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 59,
+                                "__id__": 61,
                                 "value": 0.055845
+                              },
+                              "'H2C2O4'": {
+                                "__type__": "<class 'pyomo.core.base.param.ParamData'>",
+                                "__id__": 62,
+                                "value": 0.09003
                               }
                             }
                           },
                           "Ka2": {
                             "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                            "__id__": 60,
+                            "__id__": 63,
                             "_mutable": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                                "__id__": 61,
+                                "__id__": 64,
                                 "value": 0.010232929922807542
                               }
                             }
                           },
                           "dens_mass": {
                             "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                            "__id__": 62,
+                            "__id__": 65,
                             "_mutable": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                                "__id__": 63,
+                                "__id__": 66,
                                 "value": 1
                               }
                             }
                           },
                           "cp_mol": {
                             "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                            "__id__": 64,
+                            "__id__": 67,
                             "_mutable": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                                "__id__": 65,
+                                "__id__": 68,
                                 "value": 75.327
                               }
                             }
                           },
                           "temperature_ref": {
                             "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                            "__id__": 66,
+                            "__id__": 69,
                             "_mutable": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                                "__id__": 67,
+                                "__id__": 70,
                                 "value": 298.15
                               }
                             }
@@ -401,334 +418,334 @@
                   },
                   "coal": {
                     "__type__": "<class 'idaes.core.base.process_block._ScalarCoalRefuseParameters'>",
-                    "__id__": 68,
+                    "__id__": 71,
                     "active": true,
                     "data": {
                       "None": {
                         "__type__": "<class 'idaes.core.base.process_block._ScalarCoalRefuseParameters'>",
-                        "__id__": 69,
+                        "__id__": 72,
                         "active": true,
                         "__pyomo_components__": {
                           "solid": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarPhase'>",
-                            "__id__": 70,
+                            "__id__": 73,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarPhase'>",
-                                "__id__": 71,
+                                "__id__": 74,
                                 "active": true
                               }
                             }
                           },
                           "inerts": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 72,
+                            "__id__": 75,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 73,
+                                "__id__": 76,
                                 "active": true
                               }
                             }
                           },
                           "Sc2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 74,
+                            "__id__": 77,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 75,
+                                "__id__": 78,
                                 "active": true
                               }
                             }
                           },
                           "Y2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 76,
+                            "__id__": 79,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 77,
+                                "__id__": 80,
                                 "active": true
                               }
                             }
                           },
                           "La2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 78,
+                            "__id__": 81,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 79,
+                                "__id__": 82,
                                 "active": true
                               }
                             }
                           },
                           "Ce2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 80,
+                            "__id__": 83,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 81,
+                                "__id__": 84,
                                 "active": true
                               }
                             }
                           },
                           "Pr2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 82,
+                            "__id__": 85,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 83,
+                                "__id__": 86,
                                 "active": true
                               }
                             }
                           },
                           "Nd2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 84,
+                            "__id__": 87,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 85,
+                                "__id__": 88,
                                 "active": true
                               }
                             }
                           },
                           "Sm2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 86,
+                            "__id__": 89,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 87,
+                                "__id__": 90,
                                 "active": true
                               }
                             }
                           },
                           "Gd2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 88,
+                            "__id__": 91,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 89,
+                                "__id__": 92,
                                 "active": true
                               }
                             }
                           },
                           "Dy2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 90,
+                            "__id__": 93,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 91,
+                                "__id__": 94,
                                 "active": true
                               }
                             }
                           },
                           "Al2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 92,
+                            "__id__": 95,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 93,
+                                "__id__": 96,
                                 "active": true
                               }
                             }
                           },
                           "CaO": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 94,
+                            "__id__": 97,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 95,
+                                "__id__": 98,
                                 "active": true
                               }
                             }
                           },
                           "Fe2O3": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                            "__id__": 96,
+                            "__id__": 99,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarComponent'>",
-                                "__id__": 97,
+                                "__id__": 100,
                                 "active": true
                               }
                             }
                           },
                           "mw": {
                             "__type__": "<class 'pyomo.core.base.param.IndexedParam'>",
-                            "__id__": 98,
+                            "__id__": 101,
                             "_mutable": true,
                             "data": {
                               "'inerts'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 99,
+                                "__id__": 102,
                                 "value": 0.06008
                               },
                               "'Sc2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 100,
+                                "__id__": 103,
                                 "value": 0.137889
                               },
                               "'Y2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 101,
+                                "__id__": 104,
                                 "value": 0.225807
                               },
                               "'La2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 102,
+                                "__id__": 105,
                                 "value": 0.325807
                               },
                               "'Ce2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 103,
+                                "__id__": 106,
                                 "value": 0.32822900000000005
                               },
                               "'Pr2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 104,
+                                "__id__": 107,
                                 "value": 0.329811
                               },
                               "'Nd2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 105,
+                                "__id__": 108,
                                 "value": 0.336481
                               },
                               "'Sm2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 106,
+                                "__id__": 109,
                                 "value": 0.34871700000000005
                               },
                               "'Gd2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 107,
+                                "__id__": 110,
                                 "value": 0.362497
                               },
                               "'Dy2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 108,
+                                "__id__": 111,
                                 "value": 0.372997
                               },
                               "'Al2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 109,
+                                "__id__": 112,
                                 "value": 0.101961
                               },
                               "'CaO'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 110,
+                                "__id__": 113,
                                 "value": 0.05607700000000001
                               },
                               "'Fe2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 111,
+                                "__id__": 114,
                                 "value": 0.15968700000000002
                               }
                             }
                           },
                           "mass_frac_comp_initial": {
                             "__type__": "<class 'pyomo.core.base.param.IndexedParam'>",
-                            "__id__": 112,
+                            "__id__": 115,
                             "_mutable": true,
                             "data": {
                               "'inerts'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 113,
+                                "__id__": 116,
                                 "value": 0.6952
                               },
                               "'Sc2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 114,
+                                "__id__": 117,
                                 "value": 2.77966e-05
                               },
                               "'Y2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 115,
+                                "__id__": 118,
                                 "value": 3.28653e-05
                               },
                               "'La2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 116,
+                                "__id__": 119,
                                 "value": 6.77769e-05
                               },
                               "'Ce2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 117,
+                                "__id__": 120,
                                 "value": 0.000156161
                               },
                               "'Pr2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 118,
+                                "__id__": 121,
                                 "value": 1.71438e-05
                               },
                               "'Nd2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 119,
+                                "__id__": 122,
                                 "value": 6.76618e-05
                               },
                               "'Sm2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 120,
+                                "__id__": 123,
                                 "value": 1.47926e-05
                               },
                               "'Gd2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 121,
+                                "__id__": 124,
                                 "value": 1.0405e-05
                               },
                               "'Dy2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 122,
+                                "__id__": 125,
                                 "value": 7.54827e-06
                               },
                               "'Al2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 123,
+                                "__id__": 126,
                                 "value": 0.237
                               },
                               "'CaO'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 124,
+                                "__id__": 127,
                                 "value": 0.00331
                               },
                               "'Fe2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 125,
+                                "__id__": 128,
                                 "value": 0.0642
                               }
                             }
                           },
                           "dens_mass": {
                             "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                            "__id__": 126,
+                            "__id__": 129,
                             "_mutable": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'pyomo.core.base.param.ScalarParam'>",
-                                "__id__": 127,
+                                "__id__": 130,
                                 "value": 2.4
                               }
                             }
@@ -739,144 +756,144 @@
                   },
                   "leach_rxns": {
                     "__type__": "<class 'idaes.core.base.process_block._ScalarCoalRefuseLeachingReactions'>",
-                    "__id__": 128,
+                    "__id__": 131,
                     "active": true,
                     "data": {
                       "None": {
                         "__type__": "<class 'idaes.core.base.process_block._ScalarCoalRefuseLeachingReactions'>",
-                        "__id__": 129,
+                        "__id__": 132,
                         "active": true,
                         "__pyomo_components__": {
                           "A": {
                             "__type__": "<class 'pyomo.core.base.param.IndexedParam'>",
-                            "__id__": 130,
+                            "__id__": 133,
                             "_mutable": true,
                             "data": {
                               "'Al2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 131,
+                                "__id__": 134,
                                 "value": 1.496716606
                               },
                               "'Fe2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 132,
+                                "__id__": 135,
                                 "value": 0.902948175
                               },
                               "'CaO'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 133,
+                                "__id__": 136,
                                 "value": 0.159744406
                               },
                               "'Sc2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 134,
+                                "__id__": 137,
                                 "value": 0.763763942
                               },
                               "'Y2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 135,
+                                "__id__": 138,
                                 "value": 0.580700988
                               },
                               "'La2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 136,
+                                "__id__": 139,
                                 "value": 0.443101432
                               },
                               "'Ce2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 137,
+                                "__id__": 140,
                                 "value": 0.601391182
                               },
                               "'Pr2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 138,
+                                "__id__": 141,
                                 "value": 0.501916124
                               },
                               "'Nd2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 139,
+                                "__id__": 142,
                                 "value": 0.702951111
                               },
                               "'Sm2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 140,
+                                "__id__": 143,
                                 "value": 0.578717372
                               },
                               "'Gd2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 141,
+                                "__id__": 144,
                                 "value": 1.063666638
                               },
                               "'Dy2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 142,
+                                "__id__": 145,
                                 "value": 0.428087853
                               }
                             }
                           },
                           "B": {
                             "__type__": "<class 'pyomo.core.base.param.IndexedParam'>",
-                            "__id__": 143,
+                            "__id__": 146,
                             "_mutable": true,
                             "data": {
                               "'Al2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 144,
+                                "__id__": 147,
                                 "value": 405.5050676
                               },
                               "'Fe2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 145,
+                                "__id__": 148,
                                 "value": 11.34710708
                               },
                               "'CaO'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 146,
+                                "__id__": 149,
                                 "value": 0.081844698
                               },
                               "'Sc2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 147,
+                                "__id__": 150,
                                 "value": 0.000755073
                               },
                               "'Y2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 148,
+                                "__id__": 151,
                                 "value": 0.000528612
                               },
                               "'La2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 149,
+                                "__id__": 152,
                                 "value": 0.001028295
                               },
                               "'Ce2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 150,
+                                "__id__": 153,
                                 "value": 0.007050046
                               },
                               "'Pr2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 151,
+                                "__id__": 154,
                                 "value": 0.000522858
                               },
                               "'Nd2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 152,
+                                "__id__": 155,
                                 "value": 0.006289942
                               },
                               "'Sm2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 153,
+                                "__id__": 156,
                                 "value": 0.000252479
                               },
                               "'Gd2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 154,
+                                "__id__": 157,
                                 "value": 0.013408467
                               },
                               "'Dy2O3'": {
                                 "__type__": "<class 'pyomo.core.base.param.ParamData'>",
-                                "__id__": 155,
+                                "__id__": 158,
                                 "value": 4.56708e-05
                               }
                             }
@@ -887,41 +904,41 @@
                   },
                   "leach": {
                     "__type__": "<class 'idaes.core.base.process_block._ScalarLeachingTrain'>",
-                    "__id__": 156,
+                    "__id__": 159,
                     "active": true,
                     "data": {
                       "None": {
                         "__type__": "<class 'idaes.core.base.process_block._ScalarLeachingTrain'>",
-                        "__id__": 157,
+                        "__id__": 160,
                         "active": true,
                         "__pyomo_components__": {
                           "mscontactor": {
                             "__type__": "<class 'idaes.core.base.process_block._ScalarMSContactor'>",
-                            "__id__": 158,
+                            "__id__": 161,
                             "active": true,
                             "data": {
                               "None": {
                                 "__type__": "<class 'idaes.core.base.process_block._ScalarMSContactor'>",
-                                "__id__": 159,
+                                "__id__": 162,
                                 "active": true,
                                 "__pyomo_components__": {
                                   "liquid": {
                                     "__type__": "<class 'idaes.core.base.process_block._IndexedLeachSolutionStateBlock'>",
-                                    "__id__": 160,
+                                    "__id__": 163,
                                     "active": true,
                                     "data": {
                                       "(0.0, 1)": {
                                         "__type__": "<class 'prommis.leaching.leach_solution_properties.LeachSolutionStateBlockData'>",
-                                        "__id__": 161,
+                                        "__id__": 164,
                                         "active": true,
                                         "__pyomo_components__": {
                                           "flow_vol": {
                                             "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                            "__id__": 162,
+                                            "__id__": 165,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                                "__id__": 163,
+                                                "__id__": 166,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 224.47892190149594,
@@ -932,11 +949,11 @@
                                           },
                                           "conc_mass_comp": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 164,
+                                            "__id__": 167,
                                             "data": {
                                               "'H2O'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 165,
+                                                "__id__": 168,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 1000000.0,
@@ -945,7 +962,7 @@
                                               },
                                               "'H'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 166,
+                                                "__id__": 169,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.2742309915428662,
@@ -954,25 +971,25 @@
                                               },
                                               "'HSO4'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 167,
+                                                "__id__": 170,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 881.1934905768255,
+                                                "value": 881.1934905768256,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'SO4'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 168,
+                                                "__id__": 171,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 3924.0651175214307,
+                                                "value": 3924.065117521431,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Cl'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 169,
+                                                "__id__": 172,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 9.992029456486144e-11,
@@ -981,7 +998,7 @@
                                               },
                                               "'Sc'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 170,
+                                                "__id__": 173,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.10045426786918057,
@@ -990,7 +1007,7 @@
                                               },
                                               "'Y'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 171,
+                                                "__id__": 174,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.3946264170692606,
@@ -999,52 +1016,52 @@
                                               },
                                               "'La'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 172,
+                                                "__id__": 175,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 2.238808804666449,
+                                                "value": 2.2388088046664496,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Ce'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 173,
+                                                "__id__": 176,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 5.66758904191359,
+                                                "value": 5.6675890419135895,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Pr'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 174,
+                                                "__id__": 177,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.7167083216963519,
+                                                "value": 0.7167083216963518,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Nd'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 175,
+                                                "__id__": 178,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 2.684072026427186,
+                                                "value": 2.6840720264271862,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Sm'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 176,
+                                                "__id__": 179,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.30129889758603534,
+                                                "value": 0.3012988975860354,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Gd'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 177,
+                                                "__id__": 180,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.5569395545371876,
@@ -1053,37 +1070,46 @@
                                               },
                                               "'Dy'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 178,
+                                                "__id__": 181,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.1486174004217135,
+                                                "value": 0.14861740042171354,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Al'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 179,
+                                                "__id__": 182,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 380.67285330917224,
+                                                "value": 380.6728533091723,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Ca'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 180,
+                                                "__id__": 183,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 122.97208949828436,
+                                                "value": 122.97208949828435,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Fe'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 181,
+                                                "__id__": 184,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 741.2413023533506,
+                                                "value": 741.2413023533508,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'H2C2O4'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 185,
+                                                "fixed": false,
+                                                "stale": false,
+                                                "value": 9.992029456486144e-11,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               }
@@ -1091,11 +1117,11 @@
                                           },
                                           "conc_mol_comp": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 182,
+                                            "__id__": 186,
                                             "data": {
                                               "'H2O'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 183,
+                                                "__id__": 187,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 55.55555555555556,
@@ -1104,7 +1130,7 @@
                                               },
                                               "'H'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 184,
+                                                "__id__": 188,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.0022742309915428664,
@@ -1113,7 +1139,7 @@
                                               },
                                               "'HSO4'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 185,
+                                                "__id__": 189,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.00908446897501882,
@@ -1122,16 +1148,16 @@
                                               },
                                               "'SO4'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 186,
+                                                "__id__": 190,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.040875678307514894,
+                                                "value": 0.0408756783075149,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Cl'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 187,
+                                                "__id__": 191,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.8183875712876613e-15,
@@ -1140,7 +1166,7 @@
                                               },
                                               "'Sc'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 188,
+                                                "__id__": 192,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.2349990626347296e-06,
@@ -1149,7 +1175,7 @@
                                               },
                                               "'Y'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 189,
+                                                "__id__": 193,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 4.438742669920258e-06,
@@ -1158,25 +1184,25 @@
                                               },
                                               "'La'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 190,
+                                                "__id__": 194,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 1.6117553757362578e-05,
+                                                "value": 1.611755375736258e-05,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Ce'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 191,
+                                                "__id__": 195,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 4.044926376654765e-05,
+                                                "value": 4.0449263766547644e-05,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Pr'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 192,
+                                                "__id__": 196,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 5.0863925972191e-06,
@@ -1185,16 +1211,16 @@
                                               },
                                               "'Nd'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 193,
+                                                "__id__": 197,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 1.8608117097843797e-05,
+                                                "value": 1.86081170978438e-05,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Sm'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 194,
+                                                "__id__": 198,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.0038500770553033e-06,
@@ -1203,34 +1229,34 @@
                                               },
                                               "'Gd'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 195,
+                                                "__id__": 199,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 3.541745974799285e-06,
+                                                "value": 3.5417459747992845e-06,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Dy'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 196,
+                                                "__id__": 200,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 9.145686179797753e-07,
+                                                "value": 9.145686179797754e-07,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Al'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 197,
+                                                "__id__": 201,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.014108400167117788,
+                                                "value": 0.01410840016711779,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'Ca'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 198,
+                                                "__id__": 202,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.003068319015377123,
@@ -1239,10 +1265,19 @@
                                               },
                                               "'Fe'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 199,
+                                                "__id__": 203,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.0132731901218256,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'H2C2O4'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 204,
+                                                "fixed": false,
+                                                "stale": false,
+                                                "value": 1.1098555433173546e-15,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               }
@@ -1250,11 +1285,11 @@
                                           },
                                           "temperature": {
                                             "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                            "__id__": 200,
+                                            "__id__": 205,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                                "__id__": 201,
+                                                "__id__": 206,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 298.15,
@@ -1265,11 +1300,11 @@
                                           },
                                           "pressure": {
                                             "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                            "__id__": 202,
+                                            "__id__": 207,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                                "__id__": 203,
+                                                "__id__": 208,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 101325.0,
@@ -1280,11 +1315,11 @@
                                           },
                                           "pH_phase": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 204,
+                                            "__id__": 209,
                                             "data": {
                                               "'liquid'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 205,
+                                                "__id__": 210,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.643165424964695,
@@ -1295,128 +1330,133 @@
                                           },
                                           "pH_constraint": {
                                             "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                            "__id__": 206,
+                                            "__id__": 211,
                                             "active": true,
                                             "data": {
                                               "'liquid'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 207,
+                                                "__id__": 212,
                                                 "active": true
                                               }
                                             }
                                           },
                                           "molar_concentration_constraint": {
                                             "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                            "__id__": 208,
+                                            "__id__": 213,
                                             "active": true,
                                             "data": {
                                               "'H2O'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 209,
+                                                "__id__": 214,
                                                 "active": true
                                               },
                                               "'H'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 210,
+                                                "__id__": 215,
                                                 "active": true
                                               },
                                               "'HSO4'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 211,
+                                                "__id__": 216,
                                                 "active": true
                                               },
                                               "'SO4'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 212,
+                                                "__id__": 217,
                                                 "active": true
                                               },
                                               "'Cl'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 213,
+                                                "__id__": 218,
                                                 "active": true
                                               },
                                               "'Sc'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 214,
+                                                "__id__": 219,
                                                 "active": true
                                               },
                                               "'Y'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 215,
+                                                "__id__": 220,
                                                 "active": true
                                               },
                                               "'La'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 216,
+                                                "__id__": 221,
                                                 "active": true
                                               },
                                               "'Ce'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 217,
+                                                "__id__": 222,
                                                 "active": true
                                               },
                                               "'Pr'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 218,
+                                                "__id__": 223,
                                                 "active": true
                                               },
                                               "'Nd'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 219,
+                                                "__id__": 224,
                                                 "active": true
                                               },
                                               "'Sm'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 220,
+                                                "__id__": 225,
                                                 "active": true
                                               },
                                               "'Gd'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 221,
+                                                "__id__": 226,
                                                 "active": true
                                               },
                                               "'Dy'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 222,
+                                                "__id__": 227,
                                                 "active": true
                                               },
                                               "'Al'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 223,
+                                                "__id__": 228,
                                                 "active": true
                                               },
                                               "'Ca'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 224,
+                                                "__id__": 229,
                                                 "active": true
                                               },
                                               "'Fe'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 225,
+                                                "__id__": 230,
+                                                "active": true
+                                              },
+                                              "'H2C2O4'": {
+                                                "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                                "__id__": 231,
                                                 "active": true
                                               }
                                             }
                                           },
                                           "h2o_concentration": {
                                             "__type__": "<class 'pyomo.core.base.constraint.ScalarConstraint'>",
-                                            "__id__": 226,
+                                            "__id__": 232,
                                             "active": true,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ScalarConstraint'>",
-                                                "__id__": 227,
+                                                "__id__": 233,
                                                 "active": true
                                               }
                                             }
                                           },
                                           "hso4_dissociation": {
                                             "__type__": "<class 'pyomo.core.base.constraint.ScalarConstraint'>",
-                                            "__id__": 228,
+                                            "__id__": 234,
                                             "active": true,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ScalarConstraint'>",
-                                                "__id__": 229,
+                                                "__id__": 235,
                                                 "active": true
                                               }
                                             }
@@ -1427,21 +1467,21 @@
                                   },
                                   "liquid_inlet_state": {
                                     "__type__": "<class 'idaes.core.base.process_block._IndexedLeachSolutionStateBlock'>",
-                                    "__id__": 230,
+                                    "__id__": 236,
                                     "active": true,
                                     "data": {
                                       "0.0": {
                                         "__type__": "<class 'prommis.leaching.leach_solution_properties.LeachSolutionStateBlockData'>",
-                                        "__id__": 231,
+                                        "__id__": 237,
                                         "active": true,
                                         "__pyomo_components__": {
                                           "flow_vol": {
                                             "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                            "__id__": 232,
+                                            "__id__": 238,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                                "__id__": 233,
+                                                "__id__": 239,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 224.3,
@@ -1452,63 +1492,9 @@
                                           },
                                           "conc_mass_comp": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 234,
+                                            "__id__": 240,
                                             "data": {
                                               "'H2O'": {
-                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 235,
-                                                "fixed": true,
-                                                "stale": false,
-                                                "value": 1000000.0,
-                                                "lb": 1e-20,
-                                                "ub": null
-                                              },
-                                              "'H'": {
-                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 236,
-                                                "fixed": true,
-                                                "stale": false,
-                                                "value": 100.0,
-                                                "lb": 1e-20,
-                                                "ub": null
-                                              },
-                                              "'HSO4'": {
-                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 237,
-                                                "fixed": true,
-                                                "stale": false,
-                                                "value": 1e-08,
-                                                "lb": 1e-20,
-                                                "ub": null
-                                              },
-                                              "'SO4'": {
-                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 238,
-                                                "fixed": true,
-                                                "stale": false,
-                                                "value": 4800.0,
-                                                "lb": 1e-20,
-                                                "ub": null
-                                              },
-                                              "'Cl'": {
-                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 239,
-                                                "fixed": true,
-                                                "stale": false,
-                                                "value": 1e-10,
-                                                "lb": 1e-20,
-                                                "ub": null
-                                              },
-                                              "'Sc'": {
-                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 240,
-                                                "fixed": true,
-                                                "stale": false,
-                                                "value": 1e-10,
-                                                "lb": 1e-20,
-                                                "ub": null
-                                              },
-                                              "'Y'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 241,
                                                 "fixed": true,
@@ -1517,34 +1503,34 @@
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'La'": {
+                                              "'H'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 242,
                                                 "fixed": true,
                                                 "stale": false,
-                                                "value": 1e-10,
+                                                "value": 100.0,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Ce'": {
+                                              "'HSO4'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 243,
                                                 "fixed": true,
                                                 "stale": false,
-                                                "value": 1e-10,
+                                                "value": 1e-08,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Pr'": {
+                                              "'SO4'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 244,
                                                 "fixed": true,
                                                 "stale": false,
-                                                "value": 1e-10,
+                                                "value": 4800.0,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Nd'": {
+                                              "'Cl'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 245,
                                                 "fixed": true,
@@ -1553,7 +1539,7 @@
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Sm'": {
+                                              "'Sc'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 246,
                                                 "fixed": true,
@@ -1562,7 +1548,7 @@
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Gd'": {
+                                              "'Y'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 247,
                                                 "fixed": true,
@@ -1571,7 +1557,7 @@
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Dy'": {
+                                              "'La'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 248,
                                                 "fixed": true,
@@ -1580,7 +1566,7 @@
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Al'": {
+                                              "'Ce'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 249,
                                                 "fixed": true,
@@ -1589,7 +1575,7 @@
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Ca'": {
+                                              "'Pr'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 250,
                                                 "fixed": true,
@@ -1598,9 +1584,72 @@
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
-                                              "'Fe'": {
+                                              "'Nd'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                                 "__id__": 251,
+                                                "fixed": true,
+                                                "stale": false,
+                                                "value": 1e-10,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'Sm'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 252,
+                                                "fixed": true,
+                                                "stale": false,
+                                                "value": 1e-10,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'Gd'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 253,
+                                                "fixed": true,
+                                                "stale": false,
+                                                "value": 1e-10,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'Dy'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 254,
+                                                "fixed": true,
+                                                "stale": false,
+                                                "value": 1e-10,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'Al'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 255,
+                                                "fixed": true,
+                                                "stale": false,
+                                                "value": 1e-10,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'Ca'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 256,
+                                                "fixed": true,
+                                                "stale": false,
+                                                "value": 1e-10,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'Fe'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 257,
+                                                "fixed": true,
+                                                "stale": false,
+                                                "value": 1e-10,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'H2C2O4'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 258,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 1e-10,
@@ -1611,20 +1660,20 @@
                                           },
                                           "conc_mol_comp": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 252,
+                                            "__id__": 259,
                                             "data": {
                                               "'H2O'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 253,
+                                                "__id__": 260,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 55.55555555555556,
+                                                "value": 5.555555555555556e-15,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               },
                                               "'H'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 254,
+                                                "__id__": 261,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.09999999999999999,
@@ -1633,7 +1682,7 @@
                                               },
                                               "'HSO4'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 255,
+                                                "__id__": 262,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 1.0309278350515463e-13,
@@ -1642,7 +1691,7 @@
                                               },
                                               "'SO4'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 256,
+                                                "__id__": 263,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.049999999999999996,
@@ -1651,7 +1700,7 @@
                                               },
                                               "'Cl'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 257,
+                                                "__id__": 264,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.820635771302852e-15,
@@ -1660,7 +1709,7 @@
                                               },
                                               "'Sc'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 258,
+                                                "__id__": 265,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.2248920927335022e-15,
@@ -1669,7 +1718,7 @@
                                               },
                                               "'Y'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 259,
+                                                "__id__": 266,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 1.1247961307013103e-15,
@@ -1678,7 +1727,7 @@
                                               },
                                               "'La'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 260,
+                                                "__id__": 267,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 7.199164896871962e-16,
@@ -1687,7 +1736,7 @@
                                               },
                                               "'Ce'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 261,
+                                                "__id__": 268,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 7.1369436752405155e-16,
@@ -1696,7 +1745,7 @@
                                               },
                                               "'Pr'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 262,
+                                                "__id__": 269,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 7.096879502082933e-16,
@@ -1705,7 +1754,7 @@
                                               },
                                               "'Nd'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 263,
+                                                "__id__": 270,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 6.932793499812813e-16,
@@ -1714,7 +1763,7 @@
                                               },
                                               "'Sm'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 264,
+                                                "__id__": 271,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 6.650704974727321e-16,
@@ -1723,7 +1772,7 @@
                                               },
                                               "'Gd'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 265,
+                                                "__id__": 272,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 6.359300476947535e-16,
@@ -1732,7 +1781,7 @@
                                               },
                                               "'Dy'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 266,
+                                                "__id__": 273,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 6.153846153846154e-16,
@@ -1741,7 +1790,7 @@
                                               },
                                               "'Al'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 267,
+                                                "__id__": 274,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 3.706174486694833e-15,
@@ -1750,7 +1799,7 @@
                                               },
                                               "'Ca'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 268,
+                                                "__id__": 275,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.4951344877488895e-15,
@@ -1759,10 +1808,19 @@
                                               },
                                               "'Fe'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 269,
+                                                "__id__": 276,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 1.790670606142e-15,
+                                                "lb": 1e-20,
+                                                "ub": null
+                                              },
+                                              "'H2C2O4'": {
+                                                "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                                "__id__": 277,
+                                                "fixed": false,
+                                                "stale": false,
+                                                "value": 1.1107408641563922e-15,
                                                 "lb": 1e-20,
                                                 "ub": null
                                               }
@@ -1770,11 +1828,11 @@
                                           },
                                           "temperature": {
                                             "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                            "__id__": 270,
+                                            "__id__": 278,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                                "__id__": 271,
+                                                "__id__": 279,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 298.15,
@@ -1785,11 +1843,11 @@
                                           },
                                           "pressure": {
                                             "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                            "__id__": 272,
+                                            "__id__": 280,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                                "__id__": 273,
+                                                "__id__": 281,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 101325.0,
@@ -1800,11 +1858,11 @@
                                           },
                                           "pH_phase": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 274,
+                                            "__id__": 282,
                                             "data": {
                                               "'liquid'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 275,
+                                                "__id__": 283,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 1.0,
@@ -1815,104 +1873,109 @@
                                           },
                                           "pH_constraint": {
                                             "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                            "__id__": 276,
+                                            "__id__": 284,
                                             "active": true,
                                             "data": {
                                               "'liquid'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 277,
+                                                "__id__": 285,
                                                 "active": true
                                               }
                                             }
                                           },
                                           "molar_concentration_constraint": {
                                             "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                            "__id__": 278,
+                                            "__id__": 286,
                                             "active": true,
                                             "data": {
                                               "'H2O'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 279,
+                                                "__id__": 287,
                                                 "active": true
                                               },
                                               "'H'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 280,
+                                                "__id__": 288,
                                                 "active": true
                                               },
                                               "'HSO4'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 281,
+                                                "__id__": 289,
                                                 "active": true
                                               },
                                               "'SO4'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 282,
+                                                "__id__": 290,
                                                 "active": true
                                               },
                                               "'Cl'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 283,
+                                                "__id__": 291,
                                                 "active": true
                                               },
                                               "'Sc'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 284,
+                                                "__id__": 292,
                                                 "active": true
                                               },
                                               "'Y'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 285,
+                                                "__id__": 293,
                                                 "active": true
                                               },
                                               "'La'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 286,
+                                                "__id__": 294,
                                                 "active": true
                                               },
                                               "'Ce'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 287,
+                                                "__id__": 295,
                                                 "active": true
                                               },
                                               "'Pr'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 288,
+                                                "__id__": 296,
                                                 "active": true
                                               },
                                               "'Nd'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 289,
+                                                "__id__": 297,
                                                 "active": true
                                               },
                                               "'Sm'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 290,
+                                                "__id__": 298,
                                                 "active": true
                                               },
                                               "'Gd'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 291,
+                                                "__id__": 299,
                                                 "active": true
                                               },
                                               "'Dy'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 292,
+                                                "__id__": 300,
                                                 "active": true
                                               },
                                               "'Al'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 293,
+                                                "__id__": 301,
                                                 "active": true
                                               },
                                               "'Ca'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 294,
+                                                "__id__": 302,
                                                 "active": true
                                               },
                                               "'Fe'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 295,
+                                                "__id__": 303,
+                                                "active": true
+                                              },
+                                              "'H2C2O4'": {
+                                                "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                                "__id__": 304,
                                                 "active": true
                                               }
                                             }
@@ -1923,21 +1986,21 @@
                                   },
                                   "solid": {
                                     "__type__": "<class 'idaes.core.base.process_block._IndexedCoalRefuseStateBlock'>",
-                                    "__id__": 296,
+                                    "__id__": 305,
                                     "active": true,
                                     "data": {
                                       "(0.0, 1)": {
                                         "__type__": "<class 'prommis.leaching.leach_solids_properties.CoalRefuseStateBlockData'>",
-                                        "__id__": 297,
+                                        "__id__": 306,
                                         "active": true,
                                         "__pyomo_components__": {
                                           "flow_mass": {
                                             "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                            "__id__": 298,
+                                            "__id__": 307,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                                "__id__": 299,
+                                                "__id__": 308,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 22.241185742221603,
@@ -1948,11 +2011,11 @@
                                           },
                                           "mass_frac_comp": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 300,
+                                            "__id__": 309,
                                             "data": {
                                               "'inerts'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 301,
+                                                "__id__": 310,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.7089161604396129,
@@ -1961,7 +2024,7 @@
                                               },
                                               "'Sc2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 302,
+                                                "__id__": 311,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 2.6789791580048018e-05,
@@ -1970,61 +2033,61 @@
                                               },
                                               "'Y2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 303,
+                                                "__id__": 312,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 2.845565399493663e-05,
+                                                "value": 2.8455653994936627e-05,
                                                 "lb": 1e-08,
                                                 "ub": null
                                               },
                                               "'La2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 304,
+                                                "__id__": 313,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 4.26140457206468e-05,
+                                                "value": 4.261404572064679e-05,
                                                 "lb": 1e-08,
                                                 "ub": null
                                               },
                                               "'Ce2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 305,
+                                                "__id__": 314,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 9.224196384926918e-05,
+                                                "value": 9.224196384926916e-05,
                                                 "lb": 1e-08,
                                                 "ub": null
                                               },
                                               "'Pr2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 306,
+                                                "__id__": 315,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 9.016348202921212e-06,
+                                                "value": 9.01634820292121e-06,
                                                 "lb": 1e-08,
                                                 "ub": null
                                               },
                                               "'Nd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 307,
+                                                "__id__": 316,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 3.739940770289414e-05,
+                                                "value": 3.7399407702894156e-05,
                                                 "lb": 1e-08,
                                                 "ub": null
                                               },
                                               "'Sm2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 308,
+                                                "__id__": 317,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 1.1558100522138661e-05,
+                                                "value": 1.1558100522138663e-05,
                                                 "lb": 1e-08,
                                                 "ub": null
                                               },
                                               "'Gd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 309,
+                                                "__id__": 318,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 4.13126652783932e-06,
@@ -2033,7 +2096,7 @@
                                               },
                                               "'Dy2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 310,
+                                                "__id__": 319,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 5.975687008727207e-06,
@@ -2042,25 +2105,25 @@
                                               },
                                               "'Al2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 311,
+                                                "__id__": 320,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.2344165844507926,
+                                                "value": 0.23441658445079258,
                                                 "lb": 1e-08,
                                                 "ub": null
                                               },
                                               "'CaO'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 312,
+                                                "__id__": 321,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.0016386931887040147,
+                                                "value": 0.0016386931887040152,
                                                 "lb": 1e-08,
                                                 "ub": null
                                               },
                                               "'Fe2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 313,
+                                                "__id__": 322,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.054770379655780986,
@@ -2071,11 +2134,11 @@
                                           },
                                           "conversion": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 314,
+                                            "__id__": 323,
                                             "data": {
                                               "'inerts'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 315,
+                                                "__id__": 324,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.0,
@@ -2084,25 +2147,25 @@
                                               },
                                               "'Sc2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 316,
+                                                "__id__": 325,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.05486783341758034,
+                                                "value": 0.05486783341758033,
                                                 "lb": null,
                                                 "ub": 0.999999
                                               },
                                               "'Y2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 317,
+                                                "__id__": 326,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.15092538416861437,
+                                                "value": 0.15092538416861442,
                                                 "lb": null,
                                                 "ub": 0.999999
                                               },
                                               "'La2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 318,
+                                                "__id__": 327,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.38342494088166407,
@@ -2111,16 +2174,16 @@
                                               },
                                               "'Ce2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 319,
+                                                "__id__": 328,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.42074359313120857,
+                                                "value": 0.4207435931312088,
                                                 "lb": null,
                                                 "ub": 0.999999
                                               },
                                               "'Pr2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 320,
+                                                "__id__": 329,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.48425090967291906,
@@ -2129,25 +2192,25 @@
                                               },
                                               "'Nd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 321,
+                                                "__id__": 330,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.4579540997293048,
+                                                "value": 0.4579540997293047,
                                                 "lb": null,
                                                 "ub": 0.999999
                                               },
                                               "'Sm2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 322,
+                                                "__id__": 331,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.23377407833714953,
+                                                "value": 0.23377407833714942,
                                                 "lb": null,
                                                 "ub": 0.999999
                                               },
                                               "'Gd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 323,
+                                                "__id__": 332,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.6106358012135613,
@@ -2156,25 +2219,25 @@
                                               },
                                               "'Dy2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 324,
+                                                "__id__": 333,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.2236540306278243,
+                                                "value": 0.2236540306278242,
                                                 "lb": null,
                                                 "ub": 0.999999
                                               },
                                               "'Al2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 325,
+                                                "__id__": 334,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.03003765546937112,
+                                                "value": 0.030037655469371212,
                                                 "lb": null,
                                                 "ub": 0.999999
                                               },
                                               "'CaO'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 326,
+                                                "__id__": 335,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.5145052459214582,
@@ -2183,10 +2246,10 @@
                                               },
                                               "'Fe2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 327,
+                                                "__id__": 336,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.16338507097514096,
+                                                "value": 0.16338507097514088,
                                                 "lb": null,
                                                 "ub": 0.999999
                                               }
@@ -2194,110 +2257,110 @@
                                           },
                                           "conversion_eq": {
                                             "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                            "__id__": 328,
+                                            "__id__": 337,
                                             "active": true,
                                             "data": {
                                               "'inerts'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 329,
+                                                "__id__": 338,
                                                 "active": true
                                               },
                                               "'Sc2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 330,
+                                                "__id__": 339,
                                                 "active": true
                                               },
                                               "'Y2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 331,
+                                                "__id__": 340,
                                                 "active": true
                                               },
                                               "'La2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 332,
+                                                "__id__": 341,
                                                 "active": true
                                               },
                                               "'Ce2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 333,
+                                                "__id__": 342,
                                                 "active": true
                                               },
                                               "'Pr2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 334,
+                                                "__id__": 343,
                                                 "active": true
                                               },
                                               "'Nd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 335,
+                                                "__id__": 344,
                                                 "active": true
                                               },
                                               "'Sm2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 336,
+                                                "__id__": 345,
                                                 "active": true
                                               },
                                               "'Gd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 337,
+                                                "__id__": 346,
                                                 "active": true
                                               },
                                               "'Dy2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 338,
+                                                "__id__": 347,
                                                 "active": true
                                               },
                                               "'Al2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 339,
+                                                "__id__": 348,
                                                 "active": true
                                               },
                                               "'CaO'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 340,
+                                                "__id__": 349,
                                                 "active": true
                                               },
                                               "'Fe2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 341,
+                                                "__id__": 350,
                                                 "active": true
                                               }
                                             }
                                           },
                                           "sum_mass_frac": {
                                             "__type__": "<class 'pyomo.core.base.constraint.ScalarConstraint'>",
-                                            "__id__": 342,
+                                            "__id__": 351,
                                             "active": true,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ScalarConstraint'>",
-                                                "__id__": 343,
+                                                "__id__": 352,
                                                 "active": true
                                               }
                                             }
                                           },
                                           "scaling_factor": {
                                             "__type__": "<class 'pyomo.core.base.suffix.Suffix'>",
-                                            "__id__": 344,
+                                            "__id__": 353,
                                             "data": {
-                                              "302": 100000.0,
-                                              "330": 1000.0,
-                                              "303": 100000.0,
-                                              "331": 1000.0,
-                                              "304": 100000.0,
-                                              "332": 1000.0,
-                                              "305": 100000.0,
-                                              "333": 1000.0,
-                                              "306": 100000.0,
-                                              "334": 1000.0,
-                                              "307": 100000.0,
-                                              "335": 1000.0,
-                                              "308": 100000.0,
-                                              "336": 1000.0,
-                                              "309": 100000.0,
-                                              "337": 1000.0,
-                                              "310": 100000.0,
-                                              "338": 1000.0
+                                              "311": 100000.0,
+                                              "339": 1000.0,
+                                              "312": 100000.0,
+                                              "340": 1000.0,
+                                              "313": 100000.0,
+                                              "341": 1000.0,
+                                              "314": 100000.0,
+                                              "342": 1000.0,
+                                              "315": 100000.0,
+                                              "343": 1000.0,
+                                              "316": 100000.0,
+                                              "344": 1000.0,
+                                              "317": 100000.0,
+                                              "345": 1000.0,
+                                              "318": 100000.0,
+                                              "346": 1000.0,
+                                              "319": 100000.0,
+                                              "347": 1000.0
                                             }
                                           }
                                         }
@@ -2306,21 +2369,21 @@
                                   },
                                   "solid_inlet_state": {
                                     "__type__": "<class 'idaes.core.base.process_block._IndexedCoalRefuseStateBlock'>",
-                                    "__id__": 345,
+                                    "__id__": 354,
                                     "active": true,
                                     "data": {
                                       "0.0": {
                                         "__type__": "<class 'prommis.leaching.leach_solids_properties.CoalRefuseStateBlockData'>",
-                                        "__id__": 346,
+                                        "__id__": 355,
                                         "active": true,
                                         "__pyomo_components__": {
                                           "flow_mass": {
                                             "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                            "__id__": 347,
+                                            "__id__": 356,
                                             "data": {
                                               "None": {
                                                 "__type__": "<class 'pyomo.core.base.var.ScalarVar'>",
-                                                "__id__": 348,
+                                                "__id__": 357,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 22.68,
@@ -2331,11 +2394,11 @@
                                           },
                                           "mass_frac_comp": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 349,
+                                            "__id__": 358,
                                             "data": {
                                               "'inerts'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 350,
+                                                "__id__": 359,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 0.6952,
@@ -2344,7 +2407,7 @@
                                               },
                                               "'Sc2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 351,
+                                                "__id__": 360,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 2.77966e-05,
@@ -2353,7 +2416,7 @@
                                               },
                                               "'Y2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 352,
+                                                "__id__": 361,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 3.28653e-05,
@@ -2362,7 +2425,7 @@
                                               },
                                               "'La2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 353,
+                                                "__id__": 362,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 6.77769e-05,
@@ -2371,7 +2434,7 @@
                                               },
                                               "'Ce2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 354,
+                                                "__id__": 363,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 0.000156161,
@@ -2380,7 +2443,7 @@
                                               },
                                               "'Pr2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 355,
+                                                "__id__": 364,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 1.71438e-05,
@@ -2389,7 +2452,7 @@
                                               },
                                               "'Nd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 356,
+                                                "__id__": 365,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 6.76618e-05,
@@ -2398,7 +2461,7 @@
                                               },
                                               "'Sm2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 357,
+                                                "__id__": 366,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 1.47926e-05,
@@ -2407,7 +2470,7 @@
                                               },
                                               "'Gd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 358,
+                                                "__id__": 367,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 1.0405e-05,
@@ -2416,7 +2479,7 @@
                                               },
                                               "'Dy2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 359,
+                                                "__id__": 368,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 7.548270000000001e-06,
@@ -2425,7 +2488,7 @@
                                               },
                                               "'Al2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 360,
+                                                "__id__": 369,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 0.237,
@@ -2434,7 +2497,7 @@
                                               },
                                               "'CaO'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 361,
+                                                "__id__": 370,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 0.00331,
@@ -2443,7 +2506,7 @@
                                               },
                                               "'Fe2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 362,
+                                                "__id__": 371,
                                                 "fixed": true,
                                                 "stale": false,
                                                 "value": 0.0642,
@@ -2454,11 +2517,11 @@
                                           },
                                           "conversion": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 363,
+                                            "__id__": 372,
                                             "data": {
                                               "'inerts'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 364,
+                                                "__id__": 373,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.0,
@@ -2467,7 +2530,7 @@
                                               },
                                               "'Sc2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 365,
+                                                "__id__": 374,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -1.75331058167246e-16,
@@ -2476,7 +2539,7 @@
                                               },
                                               "'Y2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 366,
+                                                "__id__": 375,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -2.9658072748167037e-16,
@@ -2485,7 +2548,7 @@
                                               },
                                               "'La2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 367,
+                                                "__id__": 376,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -1.4381322519771988e-16,
@@ -2494,7 +2557,7 @@
                                               },
                                               "'Ce2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 368,
+                                                "__id__": 377,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -1.248354529351546e-16,
@@ -2503,7 +2566,7 @@
                                               },
                                               "'Pr2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 369,
+                                                "__id__": 378,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -1.4213906168561434e-16,
@@ -2512,7 +2575,7 @@
                                               },
                                               "'Nd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 370,
+                                                "__id__": 379,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -1.440578669633876e-16,
@@ -2521,7 +2584,7 @@
                                               },
                                               "'Sm2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 371,
+                                                "__id__": 380,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -1.6473126061178127e-16,
@@ -2530,7 +2593,7 @@
                                               },
                                               "'Gd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 372,
+                                                "__id__": 381,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -1.1709772444621985e-16,
@@ -2539,7 +2602,7 @@
                                               },
                                               "'Dy2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 373,
+                                                "__id__": 382,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": -1.6141471129979685e-16,
@@ -2548,7 +2611,7 @@
                                               },
                                               "'Al2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 374,
+                                                "__id__": 383,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.0,
@@ -2557,7 +2620,7 @@
                                               },
                                               "'CaO'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 375,
+                                                "__id__": 384,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.0,
@@ -2566,7 +2629,7 @@
                                               },
                                               "'Fe2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 376,
+                                                "__id__": 385,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.0,
@@ -2577,98 +2640,98 @@
                                           },
                                           "conversion_eq": {
                                             "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                            "__id__": 377,
+                                            "__id__": 386,
                                             "active": true,
                                             "data": {
                                               "'inerts'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 378,
+                                                "__id__": 387,
                                                 "active": true
                                               },
                                               "'Sc2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 379,
+                                                "__id__": 388,
                                                 "active": true
                                               },
                                               "'Y2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 380,
+                                                "__id__": 389,
                                                 "active": true
                                               },
                                               "'La2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 381,
+                                                "__id__": 390,
                                                 "active": true
                                               },
                                               "'Ce2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 382,
+                                                "__id__": 391,
                                                 "active": true
                                               },
                                               "'Pr2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 383,
+                                                "__id__": 392,
                                                 "active": true
                                               },
                                               "'Nd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 384,
+                                                "__id__": 393,
                                                 "active": true
                                               },
                                               "'Sm2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 385,
+                                                "__id__": 394,
                                                 "active": true
                                               },
                                               "'Gd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 386,
+                                                "__id__": 395,
                                                 "active": true
                                               },
                                               "'Dy2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 387,
+                                                "__id__": 396,
                                                 "active": true
                                               },
                                               "'Al2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 388,
+                                                "__id__": 397,
                                                 "active": true
                                               },
                                               "'CaO'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 389,
+                                                "__id__": 398,
                                                 "active": true
                                               },
                                               "'Fe2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 390,
+                                                "__id__": 399,
                                                 "active": true
                                               }
                                             }
                                           },
                                           "scaling_factor": {
                                             "__type__": "<class 'pyomo.core.base.suffix.Suffix'>",
-                                            "__id__": 391,
+                                            "__id__": 400,
                                             "data": {
-                                              "351": 100000.0,
-                                              "379": 1000.0,
-                                              "352": 100000.0,
-                                              "380": 1000.0,
-                                              "353": 100000.0,
-                                              "381": 1000.0,
-                                              "354": 100000.0,
-                                              "382": 1000.0,
-                                              "355": 100000.0,
-                                              "383": 1000.0,
-                                              "356": 100000.0,
-                                              "384": 1000.0,
-                                              "357": 100000.0,
-                                              "385": 1000.0,
-                                              "358": 100000.0,
-                                              "386": 1000.0,
-                                              "359": 100000.0,
-                                              "387": 1000.0
+                                              "360": 100000.0,
+                                              "388": 1000.0,
+                                              "361": 100000.0,
+                                              "389": 1000.0,
+                                              "362": 100000.0,
+                                              "390": 1000.0,
+                                              "363": 100000.0,
+                                              "391": 1000.0,
+                                              "364": 100000.0,
+                                              "392": 1000.0,
+                                              "365": 100000.0,
+                                              "393": 1000.0,
+                                              "366": 100000.0,
+                                              "394": 1000.0,
+                                              "367": 100000.0,
+                                              "395": 1000.0,
+                                              "368": 100000.0,
+                                              "396": 1000.0
                                             }
                                           }
                                         }
@@ -2677,30 +2740,30 @@
                                   },
                                   "heterogeneous_reactions": {
                                     "__type__": "<class 'idaes.core.base.process_block._IndexedCoalRefuseLeachingReactionsBlock'>",
-                                    "__id__": 392,
+                                    "__id__": 401,
                                     "active": true,
                                     "data": {
                                       "(0.0, 1)": {
                                         "__type__": "<class 'prommis.leaching.leach_reactions.CoalRefuseLeachingReactionsData'>",
-                                        "__id__": 393,
+                                        "__id__": 402,
                                         "active": true,
                                         "__pyomo_components__": {
                                           "reaction_rate": {
                                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                            "__id__": 394,
+                                            "__id__": 403,
                                             "data": {
                                               "'Al2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 395,
+                                                "__id__": 404,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 0.004183215248410947,
+                                                "value": 0.004183215248410948,
                                                 "lb": null,
                                                 "ub": null
                                               },
                                               "'Fe2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 396,
+                                                "__id__": 405,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.003935571053768077,
@@ -2709,7 +2772,7 @@
                                               },
                                               "'CaO'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 397,
+                                                "__id__": 406,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 0.0018195456238933629,
@@ -2718,7 +2781,7 @@
                                               },
                                               "'Sc2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 398,
+                                                "__id__": 407,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 6.626890390797905e-07,
@@ -2727,7 +2790,7 @@
                                               },
                                               "'Y2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 399,
+                                                "__id__": 408,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 1.3161106713688723e-06,
@@ -2736,25 +2799,25 @@
                                               },
                                               "'La2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 400,
+                                                "__id__": 409,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 4.778939911205022e-06,
+                                                "value": 4.778939911205023e-06,
                                                 "lb": null,
                                                 "ub": null
                                               },
                                               "'Ce2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 401,
+                                                "__id__": 410,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 1.1993420584046797e-05,
+                                                "value": 1.1993420584046794e-05,
                                                 "lb": null,
                                                 "ub": null
                                               },
                                               "'Pr2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 402,
+                                                "__id__": 411,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 1.5081422994168908e-06,
@@ -2763,7 +2826,7 @@
                                               },
                                               "'Nd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 403,
+                                                "__id__": 412,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 5.517405110642077e-06,
@@ -2772,7 +2835,7 @@
                                               },
                                               "'Sm2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 404,
+                                                "__id__": 413,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 5.94152143105957e-07,
@@ -2781,7 +2844,7 @@
                                               },
                                               "'Gd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 405,
+                                                "__id__": 414,
                                                 "fixed": false,
                                                 "stale": false,
                                                 "value": 1.0501464084960796e-06,
@@ -2790,10 +2853,10 @@
                                               },
                                               "'Dy2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                                "__id__": 406,
+                                                "__id__": 415,
                                                 "fixed": false,
                                                 "stale": false,
-                                                "value": 2.7117443087535226e-07,
+                                                "value": 2.711744308753523e-07,
                                                 "lb": null,
                                                 "ub": null
                                               }
@@ -2801,93 +2864,93 @@
                                           },
                                           "reaction_rate_eq": {
                                             "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                            "__id__": 407,
+                                            "__id__": 416,
                                             "active": true,
                                             "data": {
                                               "'Al2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 408,
+                                                "__id__": 417,
                                                 "active": true
                                               },
                                               "'Fe2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 409,
+                                                "__id__": 418,
                                                 "active": true
                                               },
                                               "'CaO'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 410,
+                                                "__id__": 419,
                                                 "active": true
                                               },
                                               "'Sc2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 411,
+                                                "__id__": 420,
                                                 "active": true
                                               },
                                               "'Y2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 412,
+                                                "__id__": 421,
                                                 "active": true
                                               },
                                               "'La2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 413,
+                                                "__id__": 422,
                                                 "active": true
                                               },
                                               "'Ce2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 414,
+                                                "__id__": 423,
                                                 "active": true
                                               },
                                               "'Pr2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 415,
+                                                "__id__": 424,
                                                 "active": true
                                               },
                                               "'Nd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 416,
+                                                "__id__": 425,
                                                 "active": true
                                               },
                                               "'Sm2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 417,
+                                                "__id__": 426,
                                                 "active": true
                                               },
                                               "'Gd2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 418,
+                                                "__id__": 427,
                                                 "active": true
                                               },
                                               "'Dy2O3'": {
                                                 "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                                "__id__": 419,
+                                                "__id__": 428,
                                                 "active": true
                                               }
                                             }
                                           },
                                           "scaling_factor": {
                                             "__type__": "<class 'pyomo.core.base.suffix.Suffix'>",
-                                            "__id__": 420,
+                                            "__id__": 429,
                                             "data": {
-                                              "398": 100000.0,
+                                              "407": 100000.0,
+                                              "420": 100000.0,
+                                              "408": 100000.0,
+                                              "421": 100000.0,
+                                              "409": 100000.0,
+                                              "422": 100000.0,
+                                              "410": 100000.0,
+                                              "423": 100000.0,
                                               "411": 100000.0,
-                                              "399": 100000.0,
+                                              "424": 100000.0,
                                               "412": 100000.0,
-                                              "400": 100000.0,
+                                              "425": 100000.0,
                                               "413": 100000.0,
-                                              "401": 100000.0,
+                                              "426": 100000.0,
                                               "414": 100000.0,
-                                              "402": 100000.0,
+                                              "427": 100000.0,
                                               "415": 100000.0,
-                                              "403": 100000.0,
-                                              "416": 100000.0,
-                                              "404": 100000.0,
-                                              "417": 100000.0,
-                                              "405": 100000.0,
-                                              "418": 100000.0,
-                                              "406": 100000.0,
-                                              "419": 100000.0
+                                              "428": 100000.0
                                             }
                                           }
                                         }
@@ -2896,16 +2959,16 @@
                                   },
                                   "material_transfer_term": {
                                     "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                    "__id__": 421,
+                                    "__id__": 430,
                                     "data": {}
                                   },
                                   "heterogeneous_reaction_extent": {
                                     "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                    "__id__": 422,
+                                    "__id__": 431,
                                     "data": {
                                       "(0.0, 1, 'Al2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 423,
+                                        "__id__": 432,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 1.5835192296343281,
@@ -2914,16 +2977,16 @@
                                       },
                                       "(0.0, 1, 'Fe2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 424,
+                                        "__id__": 433,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 1.4897757043702973,
+                                        "value": 1.4897757043702975,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'CaO')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 425,
+                                        "__id__": 434,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.6887729446211566,
@@ -2932,7 +2995,7 @@
                                       },
                                       "(0.0, 1, 'Sc2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 426,
+                                        "__id__": 435,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0002508550897660274,
@@ -2941,7 +3004,7 @@
                                       },
                                       "(0.0, 1, 'Y2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 427,
+                                        "__id__": 436,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0004982020844447879,
@@ -2950,52 +3013,52 @@
                                       },
                                       "(0.0, 1, 'La2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 428,
+                                        "__id__": 437,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.00180902554549034,
+                                        "value": 0.0018090255454903403,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'Ce2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 429,
+                                        "__id__": 438,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.004540003560931889,
+                                        "value": 0.0045400035609318885,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'Pr2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 430,
+                                        "__id__": 439,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.0005708939632161553,
+                                        "value": 0.0005708939632161552,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'Nd2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 431,
+                                        "__id__": 440,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.0020885650322926335,
+                                        "value": 0.002088565032292634,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'Sm2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 432,
+                                        "__id__": 441,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.00022491105240021435,
+                                        "value": 0.00022491105240021438,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'Gd2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 433,
+                                        "__id__": 442,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0003975236589646336,
@@ -3004,10 +3067,10 @@
                                       },
                                       "(0.0, 1, 'Dy2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 434,
+                                        "__id__": 443,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.00010265068861550515,
+                                        "value": 0.00010265068861550517,
                                         "lb": null,
                                         "ub": null
                                       }
@@ -3015,11 +3078,11 @@
                                   },
                                   "liquid_inherent_reaction_extent": {
                                     "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                    "__id__": 435,
+                                    "__id__": 444,
                                     "data": {
                                       "(0.0, 1, 'Ka2')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 436,
+                                        "__id__": 445,
                                         "fixed": false,
                                         "stale": false,
                                         "value": -2.039271801536689,
@@ -3030,90 +3093,9 @@
                                   },
                                   "liquid_inherent_reaction_generation": {
                                     "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                    "__id__": 437,
+                                    "__id__": 446,
                                     "data": {
                                       "(0.0, 1, 'liquid', 'H2O')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 438,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": 0.0,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'H')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 439,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": -2.039271801536689,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'HSO4')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 440,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": 2.039271801536689,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'SO4')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 441,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": -2.039271801536689,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'Cl')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 442,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": 0.0,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'Sc')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 443,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": 0.0,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'Y')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 444,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": 0.0,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'La')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 445,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": 0.0,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'Ce')": {
-                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 446,
-                                        "fixed": false,
-                                        "stale": false,
-                                        "value": 0.0,
-                                        "lb": null,
-                                        "ub": null
-                                      },
-                                      "(0.0, 1, 'liquid', 'Pr')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                         "__id__": 447,
                                         "fixed": false,
@@ -3122,34 +3104,34 @@
                                         "lb": null,
                                         "ub": null
                                       },
-                                      "(0.0, 1, 'liquid', 'Nd')": {
+                                      "(0.0, 1, 'liquid', 'H')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                         "__id__": 448,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.0,
+                                        "value": -2.039271801536689,
                                         "lb": null,
                                         "ub": null
                                       },
-                                      "(0.0, 1, 'liquid', 'Sm')": {
+                                      "(0.0, 1, 'liquid', 'HSO4')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                         "__id__": 449,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.0,
+                                        "value": 2.039271801536689,
                                         "lb": null,
                                         "ub": null
                                       },
-                                      "(0.0, 1, 'liquid', 'Gd')": {
+                                      "(0.0, 1, 'liquid', 'SO4')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                         "__id__": 450,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.0,
+                                        "value": -2.039271801536689,
                                         "lb": null,
                                         "ub": null
                                       },
-                                      "(0.0, 1, 'liquid', 'Dy')": {
+                                      "(0.0, 1, 'liquid', 'Cl')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                         "__id__": 451,
                                         "fixed": false,
@@ -3158,7 +3140,7 @@
                                         "lb": null,
                                         "ub": null
                                       },
-                                      "(0.0, 1, 'liquid', 'Al')": {
+                                      "(0.0, 1, 'liquid', 'Sc')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                         "__id__": 452,
                                         "fixed": false,
@@ -3167,7 +3149,7 @@
                                         "lb": null,
                                         "ub": null
                                       },
-                                      "(0.0, 1, 'liquid', 'Ca')": {
+                                      "(0.0, 1, 'liquid', 'Y')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                         "__id__": 453,
                                         "fixed": false,
@@ -3176,9 +3158,99 @@
                                         "lb": null,
                                         "ub": null
                                       },
-                                      "(0.0, 1, 'liquid', 'Fe')": {
+                                      "(0.0, 1, 'liquid', 'La')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
                                         "__id__": 454,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Ce')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 455,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Pr')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 456,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Nd')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 457,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Sm')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 458,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Gd')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 459,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Dy')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 460,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Al')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 461,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Ca')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 462,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'Fe')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 463,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'H2C2O4')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 464,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0,
@@ -3189,103 +3261,108 @@
                                   },
                                   "liquid_inherent_reaction_constraint": {
                                     "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                    "__id__": 455,
+                                    "__id__": 465,
                                     "active": true,
                                     "data": {
                                       "(0.0, 1, 'liquid', 'H2O')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 456,
+                                        "__id__": 466,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'H')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 457,
+                                        "__id__": 467,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'HSO4')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 458,
+                                        "__id__": 468,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'SO4')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 459,
+                                        "__id__": 469,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Cl')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 460,
+                                        "__id__": 470,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Sc')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 461,
+                                        "__id__": 471,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Y')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 462,
+                                        "__id__": 472,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'La')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 463,
+                                        "__id__": 473,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Ce')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 464,
+                                        "__id__": 474,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Pr')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 465,
+                                        "__id__": 475,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Nd')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 466,
+                                        "__id__": 476,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Sm')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 467,
+                                        "__id__": 477,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Gd')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 468,
+                                        "__id__": 478,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Dy')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 469,
+                                        "__id__": 479,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Al')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 470,
+                                        "__id__": 480,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Ca')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 471,
+                                        "__id__": 481,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Fe')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 472,
+                                        "__id__": 482,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'liquid', 'H2C2O4')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 483,
                                         "active": true
                                       }
                                     }
                                   },
                                   "liquid_heterogeneous_reactions_generation": {
                                     "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                    "__id__": 473,
+                                    "__id__": 484,
                                     "data": {
                                       "(0.0, 1, 'liquid', 'H2O')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 474,
+                                        "__id__": 485,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 9.940105638663399,
@@ -3294,7 +3371,7 @@
                                       },
                                       "(0.0, 1, 'liquid', 'H')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 475,
+                                        "__id__": 486,
                                         "fixed": false,
                                         "stale": false,
                                         "value": -19.880211277326797,
@@ -3303,7 +3380,7 @@
                                       },
                                       "(0.0, 1, 'liquid', 'HSO4')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 476,
+                                        "__id__": 487,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0,
@@ -3312,7 +3389,7 @@
                                       },
                                       "(0.0, 1, 'liquid', 'SO4')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 477,
+                                        "__id__": 488,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0,
@@ -3321,7 +3398,7 @@
                                       },
                                       "(0.0, 1, 'liquid', 'Cl')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 478,
+                                        "__id__": 489,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0,
@@ -3330,7 +3407,7 @@
                                       },
                                       "(0.0, 1, 'liquid', 'Sc')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 479,
+                                        "__id__": 490,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0005017101795320549,
@@ -3339,7 +3416,7 @@
                                       },
                                       "(0.0, 1, 'liquid', 'Y')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 480,
+                                        "__id__": 491,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0009964041688895757,
@@ -3348,52 +3425,52 @@
                                       },
                                       "(0.0, 1, 'liquid', 'La')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 481,
+                                        "__id__": 492,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.00361805109098068,
+                                        "value": 0.0036180510909806806,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'liquid', 'Ce')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 482,
+                                        "__id__": 493,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.009080007121863779,
+                                        "value": 0.009080007121863777,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'liquid', 'Pr')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 483,
+                                        "__id__": 494,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.0011417879264323107,
+                                        "value": 0.0011417879264323104,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'liquid', 'Nd')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 484,
+                                        "__id__": 495,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.004177130064585267,
+                                        "value": 0.004177130064585268,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'liquid', 'Sm')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 485,
+                                        "__id__": 496,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.0004498221048004287,
+                                        "value": 0.00044982210480042876,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'liquid', 'Gd')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 486,
+                                        "__id__": 497,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0007950473179292672,
@@ -3402,16 +3479,16 @@
                                       },
                                       "(0.0, 1, 'liquid', 'Dy')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 487,
+                                        "__id__": 498,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 0.0002053013772310103,
+                                        "value": 0.00020530137723101034,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'liquid', 'Al')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 488,
+                                        "__id__": 499,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 3.1670384592686562,
@@ -3420,7 +3497,7 @@
                                       },
                                       "(0.0, 1, 'liquid', 'Ca')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 489,
+                                        "__id__": 500,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.6887729446211566,
@@ -3429,10 +3506,19 @@
                                       },
                                       "(0.0, 1, 'liquid', 'Fe')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 490,
+                                        "__id__": 501,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": 2.9795514087405945,
+                                        "value": 2.979551408740595,
+                                        "lb": null,
+                                        "ub": null
+                                      },
+                                      "(0.0, 1, 'liquid', 'H2C2O4')": {
+                                        "__type__": "<class 'pyomo.core.base.var.VarData'>",
+                                        "__id__": 502,
+                                        "fixed": false,
+                                        "stale": false,
+                                        "value": 0.0,
                                         "lb": null,
                                         "ub": null
                                       }
@@ -3440,195 +3526,205 @@
                                   },
                                   "liquid_heterogeneous_reaction_constraint": {
                                     "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                    "__id__": 491,
+                                    "__id__": 503,
                                     "active": true,
                                     "data": {
                                       "(0.0, 1, 'liquid', 'H2O')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 492,
+                                        "__id__": 504,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'H')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 493,
+                                        "__id__": 505,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'HSO4')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 494,
+                                        "__id__": 506,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'SO4')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 495,
+                                        "__id__": 507,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Cl')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 496,
+                                        "__id__": 508,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Sc')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 497,
+                                        "__id__": 509,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Y')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 498,
+                                        "__id__": 510,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'La')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 499,
+                                        "__id__": 511,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Ce')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 500,
+                                        "__id__": 512,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Pr')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 501,
+                                        "__id__": 513,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Nd')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 502,
+                                        "__id__": 514,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Sm')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 503,
+                                        "__id__": 515,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Gd')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 504,
+                                        "__id__": 516,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Dy')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 505,
+                                        "__id__": 517,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Al')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 506,
+                                        "__id__": 518,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Ca')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 507,
+                                        "__id__": 519,
                                         "active": true
                                       },
                                       "(0.0, 1, 'liquid', 'Fe')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 508,
+                                        "__id__": 520,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'liquid', 'H2C2O4')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 521,
                                         "active": true
                                       }
                                     }
                                   },
                                   "liquid_material_balance": {
                                     "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                    "__id__": 509,
+                                    "__id__": 522,
                                     "active": true,
                                     "data": {
                                       "(0.0, 1, 'H2O')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 510,
+                                        "__id__": 523,
                                         "active": true
                                       },
                                       "(0.0, 1, 'H')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 511,
+                                        "__id__": 524,
                                         "active": true
                                       },
                                       "(0.0, 1, 'HSO4')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 512,
+                                        "__id__": 525,
                                         "active": true
                                       },
                                       "(0.0, 1, 'SO4')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 513,
+                                        "__id__": 526,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Cl')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 514,
+                                        "__id__": 527,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Sc')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 515,
+                                        "__id__": 528,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Y')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 516,
+                                        "__id__": 529,
                                         "active": true
                                       },
                                       "(0.0, 1, 'La')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 517,
+                                        "__id__": 530,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Ce')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 518,
+                                        "__id__": 531,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Pr')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 519,
+                                        "__id__": 532,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Nd')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 520,
+                                        "__id__": 533,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Sm')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 521,
+                                        "__id__": 534,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Gd')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 522,
+                                        "__id__": 535,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Dy')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 523,
+                                        "__id__": 536,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Al')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 524,
+                                        "__id__": 537,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Ca')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 525,
+                                        "__id__": 538,
                                         "active": true
                                       },
                                       "(0.0, 1, 'Fe')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 526,
+                                        "__id__": 539,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'H2C2O4')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 540,
                                         "active": true
                                       }
                                     }
                                   },
                                   "solid_heterogeneous_reactions_generation": {
                                     "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                                    "__id__": 527,
+                                    "__id__": 541,
                                     "data": {
                                       "(0.0, 1, 'solid', 'inerts')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 528,
+                                        "__id__": 542,
                                         "fixed": false,
                                         "stale": false,
                                         "value": 0.0,
@@ -3637,7 +3733,7 @@
                                       },
                                       "(0.0, 1, 'solid', 'Sc2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 529,
+                                        "__id__": 543,
                                         "fixed": false,
                                         "stale": false,
                                         "value": -0.0002508550897660274,
@@ -3646,7 +3742,7 @@
                                       },
                                       "(0.0, 1, 'solid', 'Y2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 530,
+                                        "__id__": 544,
                                         "fixed": false,
                                         "stale": false,
                                         "value": -0.0004982020844447879,
@@ -3655,52 +3751,52 @@
                                       },
                                       "(0.0, 1, 'solid', 'La2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 531,
+                                        "__id__": 545,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": -0.00180902554549034,
+                                        "value": -0.0018090255454903403,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'solid', 'Ce2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 532,
+                                        "__id__": 546,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": -0.004540003560931889,
+                                        "value": -0.0045400035609318885,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'solid', 'Pr2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 533,
+                                        "__id__": 547,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": -0.0005708939632161553,
+                                        "value": -0.0005708939632161552,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'solid', 'Nd2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 534,
+                                        "__id__": 548,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": -0.0020885650322926335,
+                                        "value": -0.002088565032292634,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'solid', 'Sm2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 535,
+                                        "__id__": 549,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": -0.00022491105240021435,
+                                        "value": -0.00022491105240021438,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'solid', 'Gd2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 536,
+                                        "__id__": 550,
                                         "fixed": false,
                                         "stale": false,
                                         "value": -0.0003975236589646336,
@@ -3709,16 +3805,16 @@
                                       },
                                       "(0.0, 1, 'solid', 'Dy2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 537,
+                                        "__id__": 551,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": -0.00010265068861550515,
+                                        "value": -0.00010265068861550517,
                                         "lb": null,
                                         "ub": null
                                       },
                                       "(0.0, 1, 'solid', 'Al2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 538,
+                                        "__id__": 552,
                                         "fixed": false,
                                         "stale": false,
                                         "value": -1.5835192296343281,
@@ -3727,7 +3823,7 @@
                                       },
                                       "(0.0, 1, 'solid', 'CaO')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 539,
+                                        "__id__": 553,
                                         "fixed": false,
                                         "stale": false,
                                         "value": -0.6887729446211566,
@@ -3736,10 +3832,10 @@
                                       },
                                       "(0.0, 1, 'solid', 'Fe2O3')": {
                                         "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                        "__id__": 540,
+                                        "__id__": 554,
                                         "fixed": false,
                                         "stale": false,
-                                        "value": -1.4897757043702973,
+                                        "value": -1.4897757043702975,
                                         "lb": null,
                                         "ub": null
                                       }
@@ -3747,211 +3843,211 @@
                                   },
                                   "solid_heterogeneous_reaction_constraint": {
                                     "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                    "__id__": 541,
+                                    "__id__": 555,
                                     "active": true,
                                     "data": {
                                       "(0.0, 1, 'solid', 'inerts')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 542,
+                                        "__id__": 556,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Sc2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 543,
+                                        "__id__": 557,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Y2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 544,
+                                        "__id__": 558,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'La2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 545,
+                                        "__id__": 559,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Ce2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 546,
+                                        "__id__": 560,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Pr2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 547,
+                                        "__id__": 561,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Nd2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 548,
+                                        "__id__": 562,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Sm2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 549,
+                                        "__id__": 563,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Gd2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 550,
+                                        "__id__": 564,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Dy2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 551,
+                                        "__id__": 565,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'Al2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 552,
+                                        "__id__": 566,
                                         "active": true
                                       },
                                       "(0.0, 1, 'solid', 'CaO')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 553,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'solid', 'Fe2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 554,
-                                        "active": true
-                                      }
-                                    }
-                                  },
-                                  "solid_material_balance": {
-                                    "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
-                                    "__id__": 555,
-                                    "active": true,
-                                    "data": {
-                                      "(0.0, 1, 'inerts')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 556,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Sc2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 557,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Y2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 558,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'La2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 559,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Ce2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 560,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Pr2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 561,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Nd2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 562,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Sm2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 563,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Gd2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 564,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Dy2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 565,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'Al2O3')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
-                                        "__id__": 566,
-                                        "active": true
-                                      },
-                                      "(0.0, 1, 'CaO')": {
-                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 567,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Fe2O3')": {
+                                      "(0.0, 1, 'solid', 'Fe2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 568,
                                         "active": true
                                       }
                                     }
                                   },
-                                  "heterogeneous_reaction_extent_constraint": {
+                                  "solid_material_balance": {
                                     "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
                                     "__id__": 569,
                                     "active": true,
                                     "data": {
-                                      "(0.0, 1, 'Al2O3')": {
+                                      "(0.0, 1, 'inerts')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 570,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Fe2O3')": {
+                                      "(0.0, 1, 'Sc2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 571,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'CaO')": {
+                                      "(0.0, 1, 'Y2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 572,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Sc2O3')": {
+                                      "(0.0, 1, 'La2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 573,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Y2O3')": {
+                                      "(0.0, 1, 'Ce2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 574,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'La2O3')": {
+                                      "(0.0, 1, 'Pr2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 575,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Ce2O3')": {
+                                      "(0.0, 1, 'Nd2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 576,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Pr2O3')": {
+                                      "(0.0, 1, 'Sm2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 577,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Nd2O3')": {
+                                      "(0.0, 1, 'Gd2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 578,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Sm2O3')": {
+                                      "(0.0, 1, 'Dy2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 579,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Gd2O3')": {
+                                      "(0.0, 1, 'Al2O3')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 580,
                                         "active": true
                                       },
-                                      "(0.0, 1, 'Dy2O3')": {
+                                      "(0.0, 1, 'CaO')": {
                                         "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
                                         "__id__": 581,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Fe2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 582,
+                                        "active": true
+                                      }
+                                    }
+                                  },
+                                  "heterogeneous_reaction_extent_constraint": {
+                                    "__type__": "<class 'pyomo.core.base.constraint.IndexedConstraint'>",
+                                    "__id__": 583,
+                                    "active": true,
+                                    "data": {
+                                      "(0.0, 1, 'Al2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 584,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Fe2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 585,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'CaO')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 586,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Sc2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 587,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Y2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 588,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'La2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 589,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Ce2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 590,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Pr2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 591,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Nd2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 592,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Sm2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 593,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Gd2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 594,
+                                        "active": true
+                                      },
+                                      "(0.0, 1, 'Dy2O3')": {
+                                        "__type__": "<class 'pyomo.core.base.constraint.ConstraintData'>",
+                                        "__id__": 595,
                                         "active": true
                                       }
                                     }
@@ -3962,11 +4058,11 @@
                           },
                           "volume": {
                             "__type__": "<class 'pyomo.core.base.var.IndexedVar'>",
-                            "__id__": 582,
+                            "__id__": 596,
                             "data": {
                               "(0.0, 1)": {
                                 "__type__": "<class 'pyomo.core.base.var.VarData'>",
-                                "__id__": 583,
+                                "__id__": 597,
                                 "fixed": true,
                                 "stale": false,
                                 "value": 0.3785411783999999,
@@ -3977,59 +4073,59 @@
                           },
                           "recovery": {
                             "__type__": "<class 'pyomo.core.base.expression.IndexedExpression'>",
-                            "__id__": 584,
+                            "__id__": 598,
                             "data": {
                               "(0.0, 'inerts')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 585
+                                "__id__": 599
                               },
                               "(0.0, 'Sc2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 586
+                                "__id__": 600
                               },
                               "(0.0, 'Y2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 587
+                                "__id__": 601
                               },
                               "(0.0, 'La2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 588
+                                "__id__": 602
                               },
                               "(0.0, 'Ce2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 589
+                                "__id__": 603
                               },
                               "(0.0, 'Pr2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 590
+                                "__id__": 604
                               },
                               "(0.0, 'Nd2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 591
+                                "__id__": 605
                               },
                               "(0.0, 'Sm2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 592
+                                "__id__": 606
                               },
                               "(0.0, 'Gd2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 593
+                                "__id__": 607
                               },
                               "(0.0, 'Dy2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 594
+                                "__id__": 608
                               },
                               "(0.0, 'Al2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 595
+                                "__id__": 609
                               },
                               "(0.0, 'CaO')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 596
+                                "__id__": 610
                               },
                               "(0.0, 'Fe2O3')": {
                                 "__type__": "<class 'pyomo.core.base.expression.ExpressionData'>",
-                                "__id__": 597
+                                "__id__": 611
                               }
                             }
                           }
@@ -4043,7 +4139,7 @@
           },
           "scaling_factor": {
             "__type__": "<class 'pyomo.core.base.suffix.Suffix'>",
-            "__id__": 598,
+            "__id__": 612,
             "data": {}
           }
         }

--- a/src/prommis/uky/uky_flowsheet.py
+++ b/src/prommis/uky/uky_flowsheet.py
@@ -824,6 +824,7 @@ def set_operating_conditions(m):
     m.fs.leach_liquid_feed.properties[0.0].temperature.fix(Temp_room)
     m.fs.leach_liquid_feed.flow_vol.fix(224.3 * units.L / units.hour)
     m.fs.leach_liquid_feed.conc_mass_comp.fix(1e-10 * units.mg / units.L)
+    m.fs.leach_liquid_feed.conc_mass_comp[0, "H2O"].fix(1e6 * units.mg / units.L)
     m.fs.leach_liquid_feed.conc_mass_comp[0, "H"].fix(
         2 * 0.05 * 1e3 * units.mg / units.L
     )


### PR DESCRIPTION
## Addresses Issue: 
#168 

## Summary/Motivation:
The H2O concentration of the liquid leaching feed was correctly updated in the leaching flowsheet by #151, but this change was not carried over to the UKy flowsheet itself.

## Changes proposed in this PR:
- Corrects the H2O concentration for the liquid leaching feed in the UKy flowsheet
- Regenerates the leaching.json file

## Reviewer's checklist / merge requirements:
- [ ] The head branch (i.e. the "source" of the changes) is not the `main` branch on the PR author's fork
- [ ] Documentation
- [ ] Tests
- [ ] Diagnostic tests for models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
