### PR TITLE
 Update pylint version to match pyomo (v 3.3.9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ version_scheme = "only-version"
 local_scheme = "node-and-date"
 
 [tool.pylint.main]
-py-version = "3.9"
+py-version = "3.11"
 
 [tool.pylint."messages control"]
 disable = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 black[jupyter]==24.3.0
-pylint==2.17.7
-astroid==2.15.8
-pytest==7.*
+pylint==3.3.9
+astroid==3.3.11
 pytest-cov
 jupyter-book==1.0.*
 isort


### PR DESCRIPTION
## Addresses Issue: 

[Issue 192](https://github.com/prommis/prommis/issues/192)
## Summary/Motivation:
The Pyomo 6.9.5 release broke pylint testing in IDAES which is pinned to a very old version of pylint, initiating an upgrade to version 3.3.9. Check if this causes downstream effects to developers of prommis. 

## Changes proposed in this PR:
- update pylint and astroid versions
-

## Reviewer's checklist / merge requirements:
- [ ] The head branch (i.e. the "source" of the changes) is not the `main` branch on the PR author's fork
- [ ] Documentation
- [ ] Tests
- [ ] Diagnostic tests for models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
