### PR TITLE
Membrane cascade costing integration

### DIFF
--- a/src/prommis/nanofiltration/costing/diafiltration_cost_model.py
+++ b/src/prommis/nanofiltration/costing/diafiltration_cost_model.py
@@ -375,7 +375,7 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
             blk.base_pump_cost = Param(
                 initialize=622.59,
                 doc="Base cost of stainless steel, centrifugal pump",
-                units=units.USD_1996 / (units.kPa * units.m**3 / units.hr) ** 0.39,
+                units=units.USD_1996,
             )
             blk.pump_exponential_factor = Param(
                 initialize=0.39,
@@ -408,16 +408,50 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
                 doc="Unit variable operating cost",
             )
 
+            # add installation flow for separating CAPEX and OPEX considerations
+            blk.install_inlet_vol_flow = Var(
+                initialize=inlet_vol_flow.value,
+                domain=NonNegativeReals,
+                bounds=(0, 2000),
+                doc="Flow used to size pump installation (CAPEX)",
+                units=units.m**3 / units.hr
+            )
+            @blk.Constraint()
+            def install_flows_constraint(blk):
+                return blk.install_inlet_vol_flow >= inlet_vol_flow
+
+            # The pump exponentional factor is fractional, leading to the issue below:
+            # - the derivative of (flow * pressure) ** 0.39 causes numerical issues for IPOPT
+            #
+            # This is fixed with:
+            # the capital cost constraint is reformulated with an auxilliary variable as
+            #     aux_var ** (1/0.39) = (flow * pressure)
+            #     and capital_cost = base_cost * aux_var
+            blk.capital_cost_auxilliary_var = Var(
+                initialize=inlet_vol_flow.value * inlet_pressure / units.kPa,
+                domain=NonNegativeReals,
+                bounds=(0, None),
+                doc="Auxilliary variable for pump installation (CAPEX)",
+                units=units.dimensionless
+            )
+
+            @blk.Constraint()
+            def capital_cost_auxilliary_constraint(blk):
+                return (blk.capital_cost_auxilliary_var ** (1/blk.pump_exponential_factor)
+                        == blk.install_inlet_vol_flow * inlet_pressure
+                        / (units.kPa * units.m**3 / units.hr) 
+                        )
+
             # Ref [4] Eqn 5
             # assumes stainless steel centrifugal pumps
             @blk.Constraint()
             def capital_cost_constraint(blk):
                 return blk.capital_cost == units.convert(
                     blk.base_pump_cost
-                    * (inlet_vol_flow * inlet_pressure) ** blk.pump_exponential_factor,
+                    * blk.capital_cost_auxilliary_var,
                     to_units=blk.costing_package.base_currency,
                 )
-
+            
             # calculate the pump head: pump Ref [1] Eqn 1.1
             blk.pump_head = Var(
                 initialize=10,

--- a/src/prommis/nanofiltration/costing/diafiltration_cost_model.py
+++ b/src/prommis/nanofiltration/costing/diafiltration_cost_model.py
@@ -32,7 +32,7 @@ from prommis.nanofiltration.costing.diafiltration_cost_block import (
 class DiafiltrationCostingData(DiafiltrationCostingBlockData):
     """
     Costing block for the diafiltration flowsheet
-    
+
     References for default market prices:
         Na2CO3 and Li2CO3, 2021 data: https://pubs.usgs.gov/periodicals/mcs2024/mcs2024.pdf
     """
@@ -426,8 +426,9 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
                 domain=NonNegativeReals,
                 bounds=(0, 2000),
                 doc="Flow used to size pump installation (CAPEX)",
-                units=units.m**3 / units.hr
+                units=units.m**3 / units.hr,
             )
+
             @blk.Constraint()
             def install_flows_constraint(blk):
                 return blk.install_inlet_vol_flow >= inlet_vol_flow
@@ -444,26 +445,26 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
                 domain=NonNegativeReals,
                 bounds=(0, None),
                 doc="Auxilliary variable for pump installation (CAPEX)",
-                units=units.dimensionless
+                units=units.dimensionless,
             )
 
             @blk.Constraint()
             def capital_cost_auxilliary_constraint(blk):
-                return (blk.capital_cost_auxilliary_var ** (1/blk.pump_exponential_factor)
-                        == blk.install_inlet_vol_flow * inlet_pressure
-                        / (units.kPa * units.m**3 / units.hr) 
-                        )
+                return blk.capital_cost_auxilliary_var ** (
+                    1 / blk.pump_exponential_factor
+                ) == blk.install_inlet_vol_flow * inlet_pressure / (
+                    units.kPa * units.m**3 / units.hr
+                )
 
             # Ref [4] Eqn 5
             # assumes stainless steel centrifugal pumps
             @blk.Constraint()
             def capital_cost_constraint(blk):
                 return blk.capital_cost == units.convert(
-                    blk.base_pump_cost
-                    * blk.capital_cost_auxilliary_var,
+                    blk.base_pump_cost * blk.capital_cost_auxilliary_var,
                     to_units=blk.costing_package.base_currency,
                 )
-            
+
             # calculate the pump head: pump Ref [1] Eqn 1.1
             blk.pump_head = Var(
                 initialize=10,
@@ -769,8 +770,7 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
         def variable_operating_cost_constraint(blk):
             return blk.variable_operating_cost == units.convert(
                 sum(
-                    material_inlet_rates[p]
-                    * default_market_prices[p]
+                    material_inlet_rates[p] * default_market_prices[p]
                     for p in material_inlet_rates.keys()
                 ),
                 to_units=blk.costing_package.base_currency

--- a/src/prommis/nanofiltration/costing/diafiltration_cost_model.py
+++ b/src/prommis/nanofiltration/costing/diafiltration_cost_model.py
@@ -32,6 +32,9 @@ from prommis.nanofiltration.costing.diafiltration_cost_block import (
 class DiafiltrationCostingData(DiafiltrationCostingBlockData):
     """
     Costing block for the diafiltration flowsheet
+    
+    References for default market prices:
+        Na2CO3 and Li2CO3, 2021 data: https://pubs.usgs.gov/periodicals/mcs2024/mcs2024.pdf
     """
 
     def build_global_params(self):
@@ -58,6 +61,15 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
             units=units.hr / units.year,
         )
         self.operating_hours_per_year.fix()
+
+        self.default_market_prices = {
+            "Na2CO3": 0.13 * units.USD_2021 / units.kg,  # soda ash
+            "(NH4)2C2O4": 1
+            * units.USD_2021
+            / units.kg,  # TODO: add ammonium oxalate cost
+            "Li2CO3": 12 * units.USD_2021 / units.kg,  # lithium carbonate
+            "CoC2O4": 1 * units.USD_2021 / units.kg,  # TODO: add cobalt oxalate price
+        }
 
     def build_process_costs(
         self,
@@ -602,6 +614,8 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
         blk,
         precip_volume,
         precip_headspace=1.2,
+        material_inlet_rates=None,
+        default_market_prices=None,
         simple_costing=False,
     ):
         """
@@ -629,6 +643,7 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
         Args:
             precip_volume: volume of the precipitator as calculated by the unit model (m3)
             precip_headspace: precipitator headspace percentage; default value is 20%
+            material_inlet_rates: dictionary of flow rates for raw material flowrates
             simple_costing: Boolean to determine which costing method is implemented (default=False)
         """
 
@@ -741,3 +756,23 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
                     + blk.precipitator_base_cost_capital,
                     to_units=blk.costing_package.base_currency,
                 )
+
+        # either cost model
+        blk.variable_operating_cost = Var(
+            initialize=1e5,
+            domain=NonNegativeReals,
+            units=blk.costing_package.base_currency / blk.costing_package.base_period,
+            doc="Unit variable operating cost",
+        )
+
+        @blk.Constraint()
+        def variable_operating_cost_constraint(blk):
+            return blk.variable_operating_cost == units.convert(
+                sum(
+                    material_inlet_rates[p]
+                    * default_market_prices[p]
+                    for p in material_inlet_rates.keys()
+                ),
+                to_units=blk.costing_package.base_currency
+                / blk.costing_package.base_period,
+            )

--- a/src/prommis/nanofiltration/costing/diafiltration_cost_model.py
+++ b/src/prommis/nanofiltration/costing/diafiltration_cost_model.py
@@ -302,8 +302,8 @@ class DiafiltrationCostingData(DiafiltrationCostingBlockData):
 
         @blk.Constraint()
         def SEC_equation(blk):
-            return blk.SEC == units.convert(
-                (vol_flow_feed * dP / vol_flow_perm), to_units=units.kWh / units.m**3
+            return blk.SEC * vol_flow_perm == units.convert(
+                (vol_flow_feed * dP), to_units=units.kW
             )
 
         @blk.Constraint()

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
@@ -157,6 +157,17 @@ class DiafiltrationModel:
         for i in m.component_data_objects(Var):
             if i.lb == 1e-8 and "stage" not in i.name:
                 i.setlb(0)
+            i.setlb(0)
+
+        # set bounds
+        for i in m.component_data_objects(Var, active=True):
+            if 'flow_vol' in i.name or 'mass_solute' in i.name:
+                i.setlb(0)
+                i.setub(1e6)
+
+        for i in m.fs.component_data_objects(Var):
+            if 'split_fraction' in i.name:
+                i.setub(1)
 
         return m
 

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
@@ -622,7 +622,7 @@ class DiafiltrationModel:
         """Add precipitator units."""
         m.fs.precipitator = Precipitator(
             ["retentate", "permeate"],
-            outlet_list=["solid", "recycle"],
+            outlet_list=['solid', 'downstream', 'recycle'],
             yields=self.perc_precipitate,
             property_package=m.fs.properties,
             material_balance_type=MaterialBalanceType.componentTotal,
@@ -1099,6 +1099,10 @@ class DiafiltrationModel:
             m.fs.split_diafiltrate.inlet.flow_vol.setub(self.diaf["solvent"])
             m.fs.precipitator["retentate"].volume.unfix()
             m.fs.precipitator["permeate"].volume.unfix()
+            m.fs.precipitator['retentate'].yields['solvent', 'recycle'].unfix()
+            m.fs.precipitator['permeate'].yields['solvent', 'recycle'].unfix()
+            m.fs.precipitator['retentate'].split_inlet['bypass'].unfix()
+            m.fs.precipitator['permeate'].split_inlet['bypass'].unfix()
 
     def model_scaling(self, m):
         """Apply model scaling."""

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
@@ -167,12 +167,12 @@ class DiafiltrationModel:
 
         # set bounds
         for i in m.component_data_objects(Var, active=True):
-            if 'flow_vol' in i.name or 'mass_solute' in i.name:
+            if "flow_vol" in i.name or "mass_solute" in i.name:
                 i.setlb(0)
                 i.setub(1e6)
 
         for i in m.fs.component_data_objects(Var):
-            if 'split_fraction' in i.name:
+            if "split_fraction" in i.name:
                 i.setub(1)
 
         return m
@@ -628,7 +628,7 @@ class DiafiltrationModel:
         """Add precipitator units."""
         m.fs.precipitator = Precipitator(
             ["retentate", "permeate"],
-            outlet_list=['solid', 'downstream', 'recycle'],
+            outlet_list=["solid", "downstream", "recycle"],
             yields=self.perc_precipitate,
             property_package=m.fs.properties,
             material_balance_type=MaterialBalanceType.componentTotal,
@@ -1105,10 +1105,10 @@ class DiafiltrationModel:
             m.fs.split_diafiltrate.inlet.flow_vol.setub(self.diaf["solvent"])
             m.fs.precipitator["retentate"].volume.unfix()
             m.fs.precipitator["permeate"].volume.unfix()
-            m.fs.precipitator['retentate'].yields['solvent', 'recycle'].unfix()
-            m.fs.precipitator['permeate'].yields['solvent', 'recycle'].unfix()
-            m.fs.precipitator['retentate'].split_inlet['bypass'].unfix()
-            m.fs.precipitator['permeate'].split_inlet['bypass'].unfix()
+            m.fs.precipitator["retentate"].yields["solvent", "recycle"].unfix()
+            m.fs.precipitator["permeate"].yields["solvent", "recycle"].unfix()
+            m.fs.precipitator["retentate"].split_inlet["bypass"].unfix()
+            m.fs.precipitator["permeate"].split_inlet["bypass"].unfix()
 
     def model_scaling(self, m):
         """Apply model scaling."""
@@ -1161,7 +1161,6 @@ class DiafiltrationModel:
         else:
             m.fs.costing = DiafiltrationCosting()
 
-
         # Create dummy variables to store the UnitModelCostingBlocks
         # These are needed because the sieving coefficient model does not account for pressure
         m.fs.cascade = UnitModelBlock()  # to cost the pressure drop
@@ -1189,7 +1188,9 @@ class DiafiltrationModel:
                     "inlet_pressure": atmospheric_pressure * units.kPa,  # 14.7 psia
                     "outlet_pressure": 1e-5  # assume numerically 0 since SEC accounts for feed pump OPEX
                     * units.psi,  # this should make m.fs.feed_pump.costing.variable_operating_cost ~0
-                    "inlet_vol_flow": m.fs.split_feed.mixed_state[0].flow_vol, # * units.m**3 / units.h,  # feed
+                    "inlet_vol_flow": m.fs.split_feed.mixed_state[
+                        0
+                    ].flow_vol,  # * units.m**3 / units.h,  # feed
                     "simple_costing": simple_costing,
                 },
             )
@@ -1200,7 +1201,9 @@ class DiafiltrationModel:
                 costing_method_arguments={
                     "inlet_pressure": atmospheric_pressure * units.kPa,  # 14.7 psia
                     "outlet_pressure": operating_pressure * units.psi,
-                    "inlet_vol_flow": m.fs.split_feed.mixed_state[0].flow_vol, # * units.m**3 / units.h,  # feed
+                    "inlet_vol_flow": m.fs.split_feed.mixed_state[
+                        0
+                    ].flow_vol,  # * units.m**3 / units.h,  # feed
                     "simple_costing": simple_costing,
                 },
             )
@@ -1211,7 +1214,9 @@ class DiafiltrationModel:
             costing_method_arguments={
                 "inlet_pressure": atmospheric_pressure * units.kPa,  # 14.7 psia
                 "outlet_pressure": operating_pressure * units.psi,
-                "inlet_vol_flow": m.fs.split_diafiltrate.mixed_state[0].flow_vol, # * units.m**3 / units.h,  # diafiltrate
+                "inlet_vol_flow": m.fs.split_diafiltrate.mixed_state[
+                    0
+                ].flow_vol,  # * units.m**3 / units.h,  # diafiltrate
                 "simple_costing": simple_costing,
             },
         )
@@ -1237,24 +1242,16 @@ class DiafiltrationModel:
 
             # create price parameters
             m.fs.soda_ash_price = Param(
-                initialize=0.13,
-                mutable=True,
-                units=units.USD_2021 / units.kg
+                initialize=0.13, mutable=True, units=units.USD_2021 / units.kg
             )
             m.fs.ammonium_oxalate_price = Param(
-                initialize=3.10,
-                mutable=True,
-                units=units.USD_2016 / units.kg
+                initialize=3.10, mutable=True, units=units.USD_2016 / units.kg
             )
             m.fs.lithium_carbonate_price = Param(
-                initialize=10,
-                mutable=True,
-                units=units.USD_2021 / units.kg
+                initialize=10, mutable=True, units=units.USD_2021 / units.kg
             )
             m.fs.cobalt_oxalate_price = Param(
-                initialize=40,
-                mutable=True,
-                units=units.USD_2021 / units.kg
+                initialize=40, mutable=True, units=units.USD_2021 / units.kg
             )
 
             default_market_prices = {
@@ -1332,8 +1329,8 @@ class DiafiltrationModel:
                 pure_product_output_rates={
                     # 'Li': m.prec_mass_li,
                     # 'Co': m.prec_mass_co,
-                    'Li2CO3': m.prec_mass_li,
-                    'CoC2O4': m.prec_mass_co,
+                    "Li2CO3": m.prec_mass_li,
+                    "CoC2O4": m.prec_mass_co,
                 },
                 sale_prices=default_market_prices,
                 CE_index_year="2021",
@@ -1428,14 +1425,18 @@ class DiafiltrationModel:
         m.prec_li_lb.activate()
 
         if npv:
+
             def cost_obj(m):
                 # return m.fs.costing.total_annualized_cost
                 # return m.fs.costing.pv_revenue + m.fs.costing.pv_capital_cost + m.fs.costing.pv_operating_cost
                 return m.fs.costing.npv
+
             sense = maximize
         else:
+
             def cost_obj(m):
                 return m.fs.costing.total_annualized_cost
+
             sense = minimize
 
         m.cost_objective = Objective(rule=cost_obj, sense=sense)

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
@@ -1144,9 +1144,9 @@ class DiafiltrationModel:
                 costing_method=DiafiltrationCostingData.cost_membrane_pressure_drop_utility,
                 costing_method_arguments={
                     "water_flux": flux * units.m**3 / units.m**2 / units.h,
-                    "vol_flow_feed": feed["solvent"]
-                    * units.m**3
-                    / units.h,  # cascade feed
+                    "vol_flow_feed": m.fs.split_feed.mixed_state[0].flow_vol,
+                    # * units.m**3
+                    # / units.h,  # cascade feed
                     "vol_flow_perm": sum(
                         m.fs.split_permeate[i].product.flow_vol[0] for i in RangeSet(NS)
                     ),  # cascade permeate
@@ -1159,7 +1159,7 @@ class DiafiltrationModel:
                     "inlet_pressure": atmospheric_pressure * units.kPa,  # 14.7 psia
                     "outlet_pressure": 1e-5  # assume numerically 0 since SEC accounts for feed pump OPEX
                     * units.psi,  # this should make m.fs.feed_pump.costing.variable_operating_cost ~0
-                    "inlet_vol_flow": feed["solvent"] * units.m**3 / units.h,  # feed
+                    "inlet_vol_flow": m.fs.split_feed.mixed_state[0].flow_vol, # * units.m**3 / units.h,  # feed
                     "simple_costing": simple_costing,
                 },
             )
@@ -1170,7 +1170,7 @@ class DiafiltrationModel:
                 costing_method_arguments={
                     "inlet_pressure": atmospheric_pressure * units.kPa,  # 14.7 psia
                     "outlet_pressure": operating_pressure * units.psi,
-                    "inlet_vol_flow": feed["solvent"] * units.m**3 / units.h,  # feed
+                    "inlet_vol_flow": m.fs.split_feed.mixed_state[0].flow_vol, # * units.m**3 / units.h,  # feed
                     "simple_costing": simple_costing,
                 },
             )
@@ -1181,7 +1181,7 @@ class DiafiltrationModel:
             costing_method_arguments={
                 "inlet_pressure": atmospheric_pressure * units.kPa,  # 14.7 psia
                 "outlet_pressure": operating_pressure * units.psi,
-                "inlet_vol_flow": diaf["solvent"] * units.m**3 / units.h,  # diafiltrate
+                "inlet_vol_flow": m.fs.split_diafiltrate.mixed_state[0].flow_vol, # * units.m**3 / units.h,  # diafiltrate
                 "simple_costing": simple_costing,
             },
         )

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
@@ -15,6 +15,7 @@ from pyomo.core.expr import identify_components
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
+    Expression,
     Objective,
     Param,
     RangeSet,
@@ -23,10 +24,12 @@ from pyomo.environ import (
     TransformationFactory,
     Var,
     maximize,
+    minimize,
     units,
     value,
 )
 from pyomo.network import Arc
+from pyomo.environ import units as pyunits
 
 # other imports
 import idaes.logger as idaeslog
@@ -61,6 +64,9 @@ from prommis.nanofiltration.costing.diafiltration_cost_model import (
 )
 from prommis.nanofiltration.membrane_cascade_flowsheet.membrane import Membrane
 from prommis.nanofiltration.membrane_cascade_flowsheet.precipitator import Precipitator
+
+# QGESS costing
+from prommis.uky.costing.ree_plant_capcost import QGESSCosting
 
 # Custom imports
 from prommis.nanofiltration.membrane_cascade_flowsheet.solute_property import (
@@ -1126,11 +1132,35 @@ class DiafiltrationModel:
         atmospheric_pressure,
         operating_pressure,
         simple_costing,
+        npv,
+        years=15,
     ):
         """
         Adds custom costing block to the flowsheet
         """
-        m.fs.costing = DiafiltrationCosting()
+        if npv:
+            m.fs.costing = QGESSCosting(
+                discount_percentage=10,
+                plant_lifetime=years,
+            )
+            # Operation parameters to use later
+            hours_per_shift = 8
+            shifts_per_day = 3
+            operating_days_per_year = 336
+
+            m.fs.annual_operating_hours = Param(
+                initialize=hours_per_shift * shifts_per_day * operating_days_per_year,
+                mutable=True,
+                units=pyunits.hours / pyunits.a,
+            )
+            m.fs.costing.operating_hours_per_year = Param(
+                initialize=m.fs.annual_operating_hours.value,
+                mutable=True,
+                units=pyunits.hours / pyunits.a,
+            )
+        else:
+            m.fs.costing = DiafiltrationCosting()
+
 
         # Create dummy variables to store the UnitModelCostingBlocks
         # These are needed because the sieving coefficient model does not account for pressure
@@ -1198,17 +1228,119 @@ class DiafiltrationModel:
 
         # precipitator cost blocks
         if precipitate:
-            for prod in ["retentate", "permeate"]:
-                m.fs.precipitator[prod].costing = UnitModelCostingBlock(
-                    flowsheet_costing_block=m.fs.costing,
-                    costing_method=DiafiltrationCostingData.cost_precipitator,
-                    costing_method_arguments={
-                        "precip_volume": m.fs.precipitator[prod].volume,
-                        "simple_costing": simple_costing,
-                    },
-                )
+            # prices estimated using sources below:
+            # ammonium oxalate: https://www.zauba.com/export-ammonium%2Boxalate-hs-code.html
+            # oxalic acid: https://businessanalytiq.com/procurementanalytics/index/oxalic-acid-price-index/
+            #              https://www.chemanalyst.com/Pricing-data/oxalic-acid-1556
+            # cobalt oxalate: https://met3dp.sg/advanced-cobalt-oxalatekey-cutting-edge-technologies/
+            # lithium (carbonate) and cobalt: available from various sources like USGS, LME
 
-        m.fs.costing.cost_process()
+            # create price parameters
+            m.fs.soda_ash_price = Param(
+                initialize=0.13,
+                mutable=True,
+                units=units.USD_2021 / units.kg
+            )
+            m.fs.ammonium_oxalate_price = Param(
+                initialize=3.10,
+                mutable=True,
+                units=units.USD_2016 / units.kg
+            )
+            m.fs.lithium_carbonate_price = Param(
+                initialize=10,
+                mutable=True,
+                units=units.USD_2021 / units.kg
+            )
+            m.fs.cobalt_oxalate_price = Param(
+                initialize=40,
+                mutable=True,
+                units=units.USD_2021 / units.kg
+            )
+
+            default_market_prices = {
+                "Na2CO3": m.fs.soda_ash_price,
+                "(NH4)2C2O4": m.fs.ammonium_oxalate_price,
+                "Li2CO3": m.fs.lithium_carbonate_price,
+                "CoC2O4": m.fs.cobalt_oxalate_price,
+            }
+
+            # retentate raw materials
+            # TODO: add proper cost values
+            # assumes 1:1 stoichiometry of (NH4)2C2O4:CoC2O4
+            molar_mass_cobalt_oxalate = 0.147  # kg/mol
+            molar_mass_ammonium_oxalate = 0.124  # kg/mol
+            retentate_raw_materials = {
+                "(NH4)2C2O4": m.prec_mass_co
+                * molar_mass_ammonium_oxalate
+                / molar_mass_cobalt_oxalate,
+            }
+            m.fs.precipitator["retentate"].costing = UnitModelCostingBlock(
+                flowsheet_costing_block=m.fs.costing,
+                costing_method=DiafiltrationCostingData.cost_precipitator,
+                costing_method_arguments={
+                    "precip_volume": m.fs.precipitator["retentate"].volume,
+                    "material_inlet_rates": retentate_raw_materials,
+                    "default_market_prices": default_market_prices,
+                    "simple_costing": simple_costing,
+                },
+            )
+            # permeate raw materials
+            # assumes 1:1 stoichiometry of Na2CO3:Li2CO3
+            molar_mass_lithium_carbonate = 0.0739  # kg/mol
+            molar_mass_soda_ash = 0.106  # kg/mol
+            permeate_raw_materials = {
+                "Na2CO3": m.prec_mass_li
+                * molar_mass_soda_ash
+                / molar_mass_lithium_carbonate,
+            }
+            m.fs.precipitator["permeate"].costing = UnitModelCostingBlock(
+                flowsheet_costing_block=m.fs.costing,
+                costing_method=DiafiltrationCostingData.cost_precipitator,
+                costing_method_arguments={
+                    "precip_volume": m.fs.precipitator["permeate"].volume,
+                    "material_inlet_rates": permeate_raw_materials,
+                    "default_market_prices": default_market_prices,
+                    "simple_costing": simple_costing,
+                },
+            )
+
+        if npv:
+            # Define the recovery rate
+            if self.precipitate:
+                Li_product = m.prec_mass_li
+                Co_product = m.prec_mass_co
+            else:
+                Li_product = m.rec_mass_li
+                Co_product = m.rec_mass_co
+
+            m.fs.recovery_rate_per_year = Expression(
+                expr=pyunits.convert(
+                    (Li_product + Co_product) * m.fs.annual_operating_hours,
+                    to_units=pyunits.kg / pyunits.year,
+                )
+            )
+
+            m.fs.costing.build_process_costs(
+                Lang_factor=2,  # includes installation, material, construction
+                labor_types=[],  # labor costs already included in maintenance, admin
+                fixed_OM=True,
+                variable_OM=True,
+                resources=[],  # List of strings of resources.
+                rates=[],  # Resource consumption rate.
+                prices={},  # Resource prices is not considered.
+                recovery_rate_per_year=m.fs.recovery_rate_per_year,
+                pure_product_output_rates={
+                    # 'Li': m.prec_mass_li,
+                    # 'Co': m.prec_mass_co,
+                    'Li2CO3': m.prec_mass_li,
+                    'CoC2O4': m.prec_mass_co,
+                },
+                sale_prices=default_market_prices,
+                CE_index_year="2021",
+                calculate_NPV=True,
+            )
+        else:
+            m.fs.costing.cost_process()
 
     def add_costing_scaling(self, m, NS, simple_costing):
         """
@@ -1263,7 +1395,7 @@ class DiafiltrationModel:
         # Add scaling factors for poorly scaled constraints
         constraint_autoscale_large_jac(m)
 
-    def add_costing_objectives(self, m):
+    def add_costing_objectives(self, m, npv):
         """
         Method to add cost objective to flowsheet for performing optimization
 
@@ -1295,7 +1427,15 @@ class DiafiltrationModel:
         m.prec_co_lb.activate()
         m.prec_li_lb.activate()
 
-        def cost_obj(m):
-            return m.fs.costing.total_annualized_cost
+        if npv:
+            def cost_obj(m):
+                # return m.fs.costing.total_annualized_cost
+                # return m.fs.costing.pv_revenue + m.fs.costing.pv_capital_cost + m.fs.costing.pv_operating_cost
+                return m.fs.costing.npv
+            sense = maximize
+        else:
+            def cost_obj(m):
+                return m.fs.costing.total_annualized_cost
+            sense = minimize
 
-        m.cost_objective = Objective(rule=cost_obj)
+        m.cost_objective = Objective(rule=cost_obj, sense=sense)

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/diafiltration_flowsheet_model.py
@@ -161,19 +161,22 @@ class DiafiltrationModel:
 
         # set LB of all units outside of membranes to 0
         for i in m.component_data_objects(Var):
-            if i.lb == 1e-8 and "stage" not in i.name:
+            # if i.lb == 1e-8 and "stage" not in i.name:
+            #     i.setlb(0)
+            if "LN" not in i.name:
                 i.setlb(0)
-            i.setlb(0)
+            # if 'fraction' in i.name:
+            #     i.setub(1)
 
-        # set bounds
-        for i in m.component_data_objects(Var, active=True):
-            if "flow_vol" in i.name or "mass_solute" in i.name:
-                i.setlb(0)
-                i.setub(1e6)
+        # # set bounds
+        # for i in m.component_data_objects(Var, active=True):
+        #     if "flow_vol" in i.name or "mass_solute" in i.name:
+        #         i.setlb(0)
+        #         i.setub(1e6)
 
-        for i in m.fs.component_data_objects(Var):
-            if "split_fraction" in i.name:
-                i.setub(1)
+        # for i in m.fs.component_data_objects(Var):
+        #     if "split_fraction" in i.name:
+        #         i.setub(1)
 
         return m
 

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/membrane.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/membrane.py
@@ -197,7 +197,9 @@ class MembraneData(MSContactorData):
         # add new variables for each substitution
         # set initial value of variables to be reasonable small
         self.LN_M_in = Var(solutes, self.elements, initialize=5, bounds=(-18.42, 13.82))
-        self.LN_M_out = Var(solutes, self.elements, initialize=5, bounds=(-18.42, 13.82))
+        self.LN_M_out = Var(
+            solutes, self.elements, initialize=5, bounds=(-18.42, 13.82)
+        )
         self.LN_F_in = Var(self.elements, initialize=5, bounds=(-18.42, 13.82))
         self.LN_F_out = Var(self.elements, initialize=5, bounds=(-18.42, 13.82))
 

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/membrane.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/membrane.py
@@ -196,10 +196,10 @@ class MembraneData(MSContactorData):
         # Isolate nonlinear LN into LB/UB to make original sieving eqn linear
         # add new variables for each substitution
         # set initial value of variables to be reasonable small
-        self.LN_M_in = Var(solutes, self.elements, initialize=5, bounds=(-20, 15))
-        self.LN_M_out = Var(solutes, self.elements, initialize=5, bounds=(-20, 15))
-        self.LN_F_in = Var(self.elements, initialize=5, bounds=(-20, 15))
-        self.LN_F_out = Var(self.elements, initialize=5, bounds=(-20, 15))
+        self.LN_M_in = Var(solutes, self.elements, initialize=5, bounds=(-18.42, 13.82))
+        self.LN_M_out = Var(solutes, self.elements, initialize=5, bounds=(-18.42, 13.82))
+        self.LN_F_in = Var(self.elements, initialize=5, bounds=(-18.42, 13.82))
+        self.LN_F_out = Var(self.elements, initialize=5, bounds=(-18.42, 13.82))
 
         # set these as exponents to remove the logs
         #######################################################################

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/membrane.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/membrane.py
@@ -196,12 +196,16 @@ class MembraneData(MSContactorData):
         # Isolate nonlinear LN into LB/UB to make original sieving eqn linear
         # add new variables for each substitution
         # set initial value of variables to be reasonable small
-        self.LN_M_in = Var(solutes, self.elements, initialize=5, bounds=(-18.42, 13.82))
-        self.LN_M_out = Var(
-            solutes, self.elements, initialize=5, bounds=(-18.42, 13.82)
-        )
-        self.LN_F_in = Var(self.elements, initialize=5, bounds=(-18.42, 13.82))
-        self.LN_F_out = Var(self.elements, initialize=5, bounds=(-18.42, 13.82))
+        # self.LN_M_in = Var(solutes, self.elements, initialize=5, bounds=(-18.42, 13.82))
+        # self.LN_M_out = Var(
+        #     solutes, self.elements, initialize=5, bounds=(-18.42, 13.82)
+        # )
+        # self.LN_F_in = Var(self.elements, initialize=5, bounds=(-18.42, 13.82))
+        # self.LN_F_out = Var(self.elements, initialize=5, bounds=(-18.42, 13.82))
+        self.LN_M_in = Var(solutes, self.elements, initialize=5, )
+        self.LN_M_out = Var(solutes, self.elements, initialize=5, ) 
+        self.LN_F_in = Var(self.elements, initialize=5, )
+        self.LN_F_out = Var(self.elements, initialize=5, )
 
         # set these as exponents to remove the logs
         #######################################################################

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/precipitator.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/precipitator.py
@@ -58,10 +58,10 @@ class SplitterData(SeparatorData):
             raise ConfigurationError(
                 "Precipitator unit must be provided with `outlet_list` arg."
             )
-        if len(self.config.outlet_list) != 2:
-            raise ConfigurationError(
-                "Precipitator unit must be provided with two outlets."
-            )
+        # if len(self.config.outlet_list) != 2:
+        #     raise ConfigurationError(
+        #         "Precipitator unit must be provided with two outlets."
+        #     )
 
         # check yields
         sol = [i for i in self.mixed_state.component_list if i != "solvent"]
@@ -95,8 +95,57 @@ class SplitterData(SeparatorData):
         #            if i != 'solvent']
         # or include generalization for some water in precipitate
         solutes = self.mixed_state.component_list
-        self.yields = Var(solutes, self.outlet_idx)
+        self.yields = Var(solutes, self.outlet_idx, bounds=(0,1))
 
+        #####
+        # Add bypass
+        #####
+        bypass_flows = ['bypass', 'ro']
+        self.split_inlet = Var(bypass_flows, bounds=(0,1))
+        self.split_inlet_flows = Var(solutes, bypass_flows)
+
+        # set initial bypass to 0
+        self.split_inlet['bypass'].fix(1e-8)
+
+        @self.Constraint(
+            doc="Sum of bypass split frac equation"
+        )
+        def split_inlet_eqn(b):
+            return (
+                sum(b.split_inlet[i] for i in bypass_flows)
+                == 1
+            )
+
+        @self.Constraint(
+            self.flowsheet().time,
+            solutes,
+            bypass_flows,
+            doc="Precipitator outlet equations"
+        )
+        def bypass_split_eqn(b, t, sol, flows):
+            if sol == 'solvent':
+                return (
+                    b.split_inlet[flows]*b.mixed_state[t].flow_vol
+                    == b.split_inlet_flows['solvent', flows]
+                )
+            return (
+                b.split_inlet[flows]*b.mixed_state[t].flow_mass_solute[sol]
+                == b.split_inlet_flows[sol, flows]
+            )
+
+        #####
+        # Reverse osmosis
+        #####
+        # set 50% of solvent to go to recycle
+        self.yields['solvent', 'recycle'].fix(0.5)
+
+        # set solute recycle outlet to be 0
+        self.yields['Li', 'recycle'].fix(1e-8)
+        self.yields['Co', 'recycle'].fix(1e-8)
+
+        #####
+        # Product collection
+        #####
         # set solvent product outlet to be 0
         self.yields["solvent", "solid"].fix(0)
 
@@ -113,14 +162,29 @@ class SplitterData(SeparatorData):
         )
         def outlet_yield_eqn(b, t, o, sol):
             o_block = getattr(self, o + "_state")
-            if sol == "solvent":
+            if sol == 'solvent':
+                if o == 'recycle':
+                    return (
+                        b.yields[sol, o]*b.split_inlet_flows['solvent', 'ro']
+                        + b.split_inlet_flows['solvent', 'bypass']
+                        == o_block[t].flow_vol
+                    )
+                else:
+                    return (
+                        b.yields[sol, o]*b.split_inlet_flows['solvent', 'ro']
+                        == o_block[t].flow_vol
+                    )
+            if o == 'recycle':
                 return (
-                    b.yields[sol, o] * b.mixed_state[t].flow_vol == o_block[t].flow_vol
+                    b.yields[sol, o]*b.split_inlet_flows[sol, 'ro']
+                    + b.split_inlet_flows[sol, 'bypass']
+                    == o_block[t].flow_mass_solute[sol]
                 )
-            return (
-                b.yields[sol, o] * b.mixed_state[t].flow_mass_solute[sol]
-                == o_block[t].flow_mass_solute[sol]
-            )
+            else:
+                return (
+                    b.yields[sol, o]*b.split_inlet_flows[sol, 'ro']
+                    == o_block[t].flow_mass_solute[sol]
+                )
 
         # precipitator volume and residence time relations
         self.tau = Var(units=units.hour)

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/precipitator.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/precipitator.py
@@ -95,41 +95,36 @@ class SplitterData(SeparatorData):
         #            if i != 'solvent']
         # or include generalization for some water in precipitate
         solutes = self.mixed_state.component_list
-        self.yields = Var(solutes, self.outlet_idx, bounds=(0,1))
+        self.yields = Var(solutes, self.outlet_idx, bounds=(0, 1))
 
         #####
         # Add bypass
         #####
-        bypass_flows = ['bypass', 'ro']
-        self.split_inlet = Var(bypass_flows, bounds=(0,1))
+        bypass_flows = ["bypass", "ro"]
+        self.split_inlet = Var(bypass_flows, bounds=(0, 1))
         self.split_inlet_flows = Var(solutes, bypass_flows)
 
         # set initial bypass to 0
-        self.split_inlet['bypass'].fix(1e-8)
+        self.split_inlet["bypass"].fix(1e-8)
 
-        @self.Constraint(
-            doc="Sum of bypass split frac equation"
-        )
+        @self.Constraint(doc="Sum of bypass split frac equation")
         def split_inlet_eqn(b):
-            return (
-                sum(b.split_inlet[i] for i in bypass_flows)
-                == 1
-            )
+            return sum(b.split_inlet[i] for i in bypass_flows) == 1
 
         @self.Constraint(
             self.flowsheet().time,
             solutes,
             bypass_flows,
-            doc="Precipitator outlet equations"
+            doc="Precipitator outlet equations",
         )
         def bypass_split_eqn(b, t, sol, flows):
-            if sol == 'solvent':
+            if sol == "solvent":
                 return (
-                    b.split_inlet[flows]*b.mixed_state[t].flow_vol
-                    == b.split_inlet_flows['solvent', flows]
+                    b.split_inlet[flows] * b.mixed_state[t].flow_vol
+                    == b.split_inlet_flows["solvent", flows]
                 )
             return (
-                b.split_inlet[flows]*b.mixed_state[t].flow_mass_solute[sol]
+                b.split_inlet[flows] * b.mixed_state[t].flow_mass_solute[sol]
                 == b.split_inlet_flows[sol, flows]
             )
 
@@ -137,11 +132,11 @@ class SplitterData(SeparatorData):
         # Reverse osmosis
         #####
         # set 50% of solvent to go to recycle
-        self.yields['solvent', 'recycle'].fix(0.5)
+        self.yields["solvent", "recycle"].fix(0.5)
 
         # set solute recycle outlet to be 0
-        self.yields['Li', 'recycle'].fix(1e-8)
-        self.yields['Co', 'recycle'].fix(1e-8)
+        self.yields["Li", "recycle"].fix(1e-8)
+        self.yields["Co", "recycle"].fix(1e-8)
 
         #####
         # Product collection
@@ -162,27 +157,27 @@ class SplitterData(SeparatorData):
         )
         def outlet_yield_eqn(b, t, o, sol):
             o_block = getattr(self, o + "_state")
-            if sol == 'solvent':
-                if o == 'recycle':
+            if sol == "solvent":
+                if o == "recycle":
                     return (
-                        b.yields[sol, o]*b.split_inlet_flows['solvent', 'ro']
-                        + b.split_inlet_flows['solvent', 'bypass']
+                        b.yields[sol, o] * b.split_inlet_flows["solvent", "ro"]
+                        + b.split_inlet_flows["solvent", "bypass"]
                         == o_block[t].flow_vol
                     )
                 else:
                     return (
-                        b.yields[sol, o]*b.split_inlet_flows['solvent', 'ro']
+                        b.yields[sol, o] * b.split_inlet_flows["solvent", "ro"]
                         == o_block[t].flow_vol
                     )
-            if o == 'recycle':
+            if o == "recycle":
                 return (
-                    b.yields[sol, o]*b.split_inlet_flows[sol, 'ro']
-                    + b.split_inlet_flows[sol, 'bypass']
+                    b.yields[sol, o] * b.split_inlet_flows[sol, "ro"]
+                    + b.split_inlet_flows[sol, "bypass"]
                     == o_block[t].flow_mass_solute[sol]
                 )
             else:
                 return (
-                    b.yields[sol, o]*b.split_inlet_flows[sol, 'ro']
+                    b.yields[sol, o] * b.split_inlet_flows[sol, "ro"]
                     == o_block[t].flow_mass_solute[sol]
                 )
 

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/solve_diafiltration.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/solve_diafiltration.py
@@ -97,6 +97,7 @@ def main(args):
     atmospheric_pressure = 101.325  # ambient pressure, kPa
     operating_pressure = 145  # nanofiltration operating pressure, psi
     simple_costing = False
+    npv = False
     if costing:
         df.add_costing(
             m,
@@ -108,13 +109,14 @@ def main(args):
             atmospheric_pressure=atmospheric_pressure,
             operating_pressure=operating_pressure,
             simple_costing=simple_costing,
+            npv=npv,
         )
-        df.add_costing_objectives(m)
+        df.add_costing_objectives(m, npv=npv)
         df.add_costing_scaling(m, NS=num_s, simple_costing=simple_costing)
 
     # set recovery lower bounds
-    lithium_recovery = 0.8
-    cobalt_recovery = 0.8
+    lithium_recovery = 0.7
+    cobalt_recovery = 0.7
 
     solve_scaled_model(
         m,

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/utils.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/utils.py
@@ -243,10 +243,10 @@ def report_values(m, prec=True):
             pyo.value(m.fs.precipitator["retentate"].volume),
             pyo.value(m.fs.precipitator["permeate"].volume),
         ]
-        m.fs.precipitator['retentate'].yields['solvent', 'recycle'].pprint()
-        m.fs.precipitator['permeate'].yields['solvent', 'recycle'].pprint()
-        m.fs.precipitator['retentate'].split_inlet['bypass'].pprint()
-        m.fs.precipitator['permeate'].split_inlet['bypass'].pprint()
+        m.fs.precipitator["retentate"].yields["solvent", "recycle"].pprint()
+        m.fs.precipitator["permeate"].yields["solvent", "recycle"].pprint()
+        m.fs.precipitator["retentate"].split_inlet["bypass"].pprint()
+        m.fs.precipitator["permeate"].split_inlet["bypass"].pprint()
     return data
 
 
@@ -883,6 +883,7 @@ def visualize_flows(num_boxes, num_sub_boxes, conf="stage", model=None):
     # Show the plot
     plt.show()
 
+
 def sep_dof(m, mixing, first, second):
     """Separate model DoF into first and second stage."""
     NS = len(m.fs.stages)
@@ -894,7 +895,7 @@ def sep_dof(m, mixing, first, second):
     # second stage variables
     second_stage_variables = second
 
-    if mixing == 'tube':
+    if mixing == "tube":
         for i in m.fs.stages:
             for j in m.fs.tubes:
                 if i != NS or j != NT:
@@ -906,15 +907,11 @@ def sep_dof(m, mixing, first, second):
                     #     .split_fraction[0, f'outlet_{(i-1)*NT+j}']
                     # )
                     second_stage_variables.append(
-                        getattr(
-                            m.fs.split_feed,
-                            f'outlet_{(i-1)*NT+j}'
-                        ).flow_vol[0]
+                        getattr(m.fs.split_feed, f"outlet_{(i-1)*NT+j}").flow_vol[0]
                     )
                     second_stage_variables.append(
                         getattr(
-                            m.fs.split_diafiltrate,
-                            f'outlet_{(i-1)*NT+j}'
+                            m.fs.split_diafiltrate, f"outlet_{(i-1)*NT+j}"
                         ).flow_vol[0]
                     )
                 if j != NT:
@@ -924,10 +921,9 @@ def sep_dof(m, mixing, first, second):
                         #     .split_fraction[0, f'outlet_{j}']
                         # )
                         second_stage_variables.append(
-                            getattr(
-                                m.fs.recycle_splitters[i],
-                                f'outlet_{j}'
-                            ).flow_vol[0]
+                            getattr(m.fs.recycle_splitters[i], f"outlet_{j}").flow_vol[
+                                0
+                            ]
                         )
             if i != 1:
                 # second_stage_variables.append(
@@ -944,7 +940,7 @@ def sep_dof(m, mixing, first, second):
                     m.fs.split_permeate[i].product.flow_vol[0]
                 )
 
-    elif mixing == 'stage' or mixing == 'simple' or mixing == 'classic':
+    elif mixing == "stage" or mixing == "simple" or mixing == "classic":
         for i in m.fs.stages:
             if i > 1:
                 # second_stage_variables.append(
@@ -955,18 +951,12 @@ def sep_dof(m, mixing, first, second):
                 #     .split_fraction[0, f'outlet_{i}']
                 # )
                 second_stage_variables.append(
-                    getattr(
-                        m.fs.split_feed,
-                        f'outlet_{i}'
-                    ).flow_vol[0]
+                    getattr(m.fs.split_feed, f"outlet_{i}").flow_vol[0]
                 )
                 second_stage_variables.append(
-                    getattr(
-                        m.fs.split_diafiltrate,
-                        f'outlet_{i}'
-                    ).flow_vol[0]
+                    getattr(m.fs.split_diafiltrate, f"outlet_{i}").flow_vol[0]
                 )
-            if mixing != 'classic':
+            if mixing != "classic":
                 if i != 1:
                     # second_stage_variables.append(
                     #     m.fs.split_retentate[i].split_fraction[0, 'product']
@@ -981,16 +971,13 @@ def sep_dof(m, mixing, first, second):
                     second_stage_variables.append(
                         m.fs.split_permeate[i].product.flow_vol[0]
                     )
-            if mixing == 'stage':
-                for j in pyo.RangeSet(NT-1):
+            if mixing == "stage":
+                for j in pyo.RangeSet(NT - 1):
                     # second_stage_variables.append(
                     #     m.fs.splitters[i].split_fraction[0, f'outlet_{j}']
                     # )
                     second_stage_variables.append(
-                        getattr(
-                            m.fs.splitters[i],
-                            f'outlet_{j}'
-                        ).flow_vol[0]
+                        getattr(m.fs.splitters[i], f"outlet_{j}").flow_vol[0]
                     )
 
     return first_stage_variables, second_stage_variables

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/utils.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/utils.py
@@ -243,6 +243,10 @@ def report_values(m, prec=True):
             pyo.value(m.fs.precipitator["retentate"].volume),
             pyo.value(m.fs.precipitator["permeate"].volume),
         ]
+        m.fs.precipitator['retentate'].yields['solvent', 'recycle'].pprint()
+        m.fs.precipitator['permeate'].yields['solvent', 'recycle'].pprint()
+        m.fs.precipitator['retentate'].split_inlet['bypass'].pprint()
+        m.fs.precipitator['permeate'].split_inlet['bypass'].pprint()
     return data
 
 
@@ -878,3 +882,115 @@ def visualize_flows(num_boxes, num_sub_boxes, conf="stage", model=None):
 
     # Show the plot
     plt.show()
+
+def sep_dof(m, mixing, first, second):
+    """Separate model DoF into first and second stage."""
+    NS = len(m.fs.stages)
+    NT = len(m.fs.tubes)
+
+    # first stage variables
+    first_stage_variables = first
+
+    # second stage variables
+    second_stage_variables = second
+
+    if mixing == 'tube':
+        for i in m.fs.stages:
+            for j in m.fs.tubes:
+                if i != NS or j != NT:
+                    # second_stage_variables.append(
+                    #     m.fs.split_feed.split_fraction[0, f'outlet_{(i-1)*NT+j}']
+                    # )
+                    # second_stage_variables.append(
+                    #     m.fs.split_diafiltrate
+                    #     .split_fraction[0, f'outlet_{(i-1)*NT+j}']
+                    # )
+                    second_stage_variables.append(
+                        getattr(
+                            m.fs.split_feed,
+                            f'outlet_{(i-1)*NT+j}'
+                        ).flow_vol[0]
+                    )
+                    second_stage_variables.append(
+                        getattr(
+                            m.fs.split_diafiltrate,
+                            f'outlet_{(i-1)*NT+j}'
+                        ).flow_vol[0]
+                    )
+                if j != NT:
+                    if i != 1:
+                        # second_stage_variables.append(
+                        #     m.fs.recycle_splitters[i]
+                        #     .split_fraction[0, f'outlet_{j}']
+                        # )
+                        second_stage_variables.append(
+                            getattr(
+                                m.fs.recycle_splitters[i],
+                                f'outlet_{j}'
+                            ).flow_vol[0]
+                        )
+            if i != 1:
+                # second_stage_variables.append(
+                #     m.fs.split_retentate[i].split_fraction[0, 'product']
+                # )
+                second_stage_variables.append(
+                    m.fs.split_retentate[i].product.flow_vol[0]
+                )
+            if i != NS:
+                # second_stage_variables.append(
+                #     m.fs.split_permeate[i].split_fraction[0, 'product']
+                # )
+                second_stage_variables.append(
+                    m.fs.split_permeate[i].product.flow_vol[0]
+                )
+
+    elif mixing == 'stage' or mixing == 'simple' or mixing == 'classic':
+        for i in m.fs.stages:
+            if i > 1:
+                # second_stage_variables.append(
+                #     m.fs.split_feed.split_fraction[0, f'outlet_{i}']
+                # )
+                # second_stage_variables.append(
+                #     m.fs.split_diafiltrate
+                #     .split_fraction[0, f'outlet_{i}']
+                # )
+                second_stage_variables.append(
+                    getattr(
+                        m.fs.split_feed,
+                        f'outlet_{i}'
+                    ).flow_vol[0]
+                )
+                second_stage_variables.append(
+                    getattr(
+                        m.fs.split_diafiltrate,
+                        f'outlet_{i}'
+                    ).flow_vol[0]
+                )
+            if mixing != 'classic':
+                if i != 1:
+                    # second_stage_variables.append(
+                    #     m.fs.split_retentate[i].split_fraction[0, 'product']
+                    # )
+                    second_stage_variables.append(
+                        m.fs.split_retentate[i].product.flow_vol[0]
+                    )
+                if i != NS:
+                    # second_stage_variables.append(
+                    #     m.fs.split_permeate[i].split_fraction[0, 'product']
+                    # )
+                    second_stage_variables.append(
+                        m.fs.split_permeate[i].product.flow_vol[0]
+                    )
+            if mixing == 'stage':
+                for j in pyo.RangeSet(NT-1):
+                    # second_stage_variables.append(
+                    #     m.fs.splitters[i].split_fraction[0, f'outlet_{j}']
+                    # )
+                    second_stage_variables.append(
+                        getattr(
+                            m.fs.splitters[i],
+                            f'outlet_{j}'
+                        ).flow_vol[0]
+                    )
+
+    return first_stage_variables, second_stage_variables

--- a/src/prommis/nanofiltration/membrane_cascade_flowsheet/utils.py
+++ b/src/prommis/nanofiltration/membrane_cascade_flowsheet/utils.py
@@ -243,10 +243,20 @@ def report_values(m, prec=True):
             pyo.value(m.fs.precipitator["retentate"].volume),
             pyo.value(m.fs.precipitator["permeate"].volume),
         ]
+        print("\nconc. step recycle")
+        data["conc step recycle"] = [pyo.value(m.fs.precipitator["retentate"].yields["solvent", "recycle"]), pyo.value(m.fs.precipitator["permeate"].yields["solvent", "recycle"])]
         m.fs.precipitator["retentate"].yields["solvent", "recycle"].pprint()
         m.fs.precipitator["permeate"].yields["solvent", "recycle"].pprint()
+        print("\nbypass recycle")
+        data["bypass recycle"] = [pyo.value(m.fs.precipitator["retentate"].split_inlet["bypass"]), pyo.value(m.fs.precipitator["permeate"].split_inlet["bypass"])]
         m.fs.precipitator["retentate"].split_inlet["bypass"].pprint()
         m.fs.precipitator["permeate"].split_inlet["bypass"].pprint()
+        print("\npump power (kW)")
+        data["pump power"] = [pyo.value(m.fs.diafiltrate_pump.costing.pump_power)/8766]
+        print(pyo.value(m.fs.diafiltrate_pump.costing.pump_power)/8766)
+        print("\ncost")
+        data["cost"] = [pyo.value(m.cost_objective)]
+        print(pyo.value(m.cost_objective))
     return data
 
 
@@ -256,7 +266,7 @@ def visualize_flows(num_boxes, num_sub_boxes, conf="stage", model=None):
     box_size = 1  # Size of each box (width and height)
     spacing = 0.3  # Space between the boxes
     thick_line_width = 2  # Thickness of the outer box lines
-    tol = 0.001
+    tol = 0.1
     legflagret = True
     legflagperm = True
     legflagrec = True
@@ -267,7 +277,7 @@ def visualize_flows(num_boxes, num_sub_boxes, conf="stage", model=None):
             "size": [1] * num_boxes * num_sub_boxes,
             "solutes": [1] * num_boxes * num_sub_boxes,
             "Membrane outlet recoveries": [1] * num_boxes * num_sub_boxes,
-            "Membrane Area": [1] * num_boxes * num_sub_boxes,
+            "Membrane Area": [100] * num_boxes * num_sub_boxes,
             "feed flows": [1] * num_boxes * num_sub_boxes,
             "diaf flows": [1] * num_boxes * num_sub_boxes,
             "recycle flows": [1] * num_boxes * num_sub_boxes,


### PR DESCRIPTION
## Addresses Issue: 
Fixes bug in #106 where pump operating costs remain constant and do not depend on inlet flows.

## Summary/Motivation:
This work builds on #106 and fully integrates it into the membrane diafiltration cascade flowsheet.
Reformulations for SEC and pump costing equations are introduced to improve numerical tractability and provide differentiation between first stage design decisions and second stage operational decisions.
Product collection updates from #182 are included in the flowsheet to be included with latest costing updates.

## Changes proposed in this PR:
- Replace constant value used in `cost_pump` with corresponding flow variables to fix bug.
- Update `diafiltration_cost_model` SEC and pump costing constraint formulations
- Update `solve_diafiltration` to use options from latest cost modeling updates
- TODO: Update unit tests with new expected values.

## Reviewer's checklist / merge requirements:
- [ ] The head branch (i.e. the "source" of the changes) is not the `main` branch on the PR author's fork
- [ ] Documentation
- [ ] Tests
- [ ] Diagnostic tests for models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
