### PR TITLE
Fix issue #236

### DIFF
--- a/docs/tutorials/costing_basic_features-solution.ipynb
+++ b/docs/tutorials/costing_basic_features-solution.ipynb
@@ -173,8 +173,8 @@
       "'fs.leach_tanks.mscontactor.solid[0.0,1].conversion_comp[Nd2O3]' to a numeric\n",
       "value `-7.778855753596789e-13` outside the bounds (0, 0.99999999).\n",
       "    See also https://pyomo.readthedocs.io/en/stable/errors.html#w1002\n",
-      "2026-01-19 16:37:40 [INFO] idaes.init.fs.leach_tanks.mscontactor: Stream Initialization Completed.\n",
-      "2026-01-19 16:37:40 [INFO] idaes.init.fs.leach_tanks.mscontactor: Initialization Completed, optimal - <undefined>\n",
+      "2026-04-17 13:20:16 [INFO] idaes.init.fs.leach_tanks.mscontactor: Stream Initialization Completed.\n",
+      "2026-04-17 13:20:16 [INFO] idaes.init.fs.leach_tanks.mscontactor: Initialization Completed, optimal - <undefined>\n",
       "Ipopt 3.13.2: \n",
       "\n",
       "******************************************************************************\n",
@@ -518,7 +518,7 @@
       "Number of equality constraint Jacobian evaluations   = 4\n",
       "Number of inequality constraint Jacobian evaluations = 0\n",
       "Number of Lagrangian Hessian evaluations             = 3\n",
-      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.001\n",
+      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.000\n",
       "Total CPU secs in NLP function evaluations           =      0.000\n",
       "\n",
       "EXIT: Optimal Solution Found.\n"
@@ -1223,7 +1223,7 @@
       "Number of equality constraint Jacobian evaluations   = 4\n",
       "Number of inequality constraint Jacobian evaluations = 0\n",
       "Number of Lagrangian Hessian evaluations             = 3\n",
-      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.000\n",
+      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.002\n",
       "Total CPU secs in NLP function evaluations           =      0.000\n",
       "\n",
       "EXIT: Optimal Solution Found.\n",
@@ -1478,14 +1478,14 @@
     "assert m.fs.costing_5.total_plant_cost.value == pytest.approx(133.23, rel=1e-4)\n",
     "assert m.fs.costing_5.total_fixed_OM_cost.value == pytest.approx(11.916, rel=1e-4)\n",
     "assert m.fs.costing_5.total_sales_revenue.value == pytest.approx(27.654, rel=1e-4)\n",
-    "assert m.fs.costing_5.total_variable_OM_cost[0].value == pytest.approx(526.91, rel=1e-4)\n",
-    "assert m.fs.costing_5.plant_overhead_cost[0].value == pytest.approx(89.638, rel=1e-4)\n",
-    "assert value(m.fs.costing_5.cost_of_recovery) == pytest.approx(2178.7, rel=1e-4)"
+    "assert m.fs.costing_5.total_variable_OM_cost[0].value == pytest.approx(532.95, rel=1e-4)\n",
+    "assert m.fs.costing_5.plant_overhead_cost[0].value == pytest.approx(90.644, rel=1e-4)\n",
+    "assert value(m.fs.costing_5.cost_of_recovery) == pytest.approx(2202.434, rel=1e-4)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "id": "08a3cfb9-37a5-4d1c-b481-6f0bff5f0a61",
    "metadata": {},
    "outputs": [
@@ -1530,15 +1530,15 @@
       "    Total Property Taxes and Insurance Cost                                      1.3323\n",
       "    Total Other Fixed Costs                                                      1.0000\n",
       "    Total Variable Power Cost                                                    6.7935\n",
-      "    Total Variable Waste Cost                                                5.0282e-06\n",
+      "    Total Variable Waste Cost                                                    5.0282\n",
       "    Total Variable Chemicals Cost                                                428.26\n",
-      "    General Plant Overhead Cost                                                  89.638\n",
-      "    Total Plant Overhead Cost, Including Maintenance & Quality Assurance         92.683\n",
-      "    Total Variable Operating & Maintenance Cost                                  526.91\n",
+      "    General Plant Overhead Cost                                                  90.644\n",
+      "    Total Plant Overhead Cost, Including Maintenance & Quality Assurance         93.689\n",
+      "    Total Variable Operating & Maintenance Cost                                  532.95\n",
       "    Total Land Cost                                                              1.2247\n",
       "    Total Transport Cost                                                      0.0024134\n",
       "    Total Sales Revenue Cost                                                     27.654\n",
-      "    Cost of Recovery (USD/kg REE)                                                2178.7\n",
+      "    Cost of Recovery (USD/kg REE)                                                2202.4\n",
       "====================================================================================\n",
       "\n"
      ]

--- a/src/prommis/precipitate/precipitate_solids_properties.py
+++ b/src/prommis/precipitate/precipitate_solids_properties.py
@@ -196,6 +196,7 @@ class PrecipitateStateBlockData(StateBlockData):
 
         iscale.set_scaling_factor(self.flow_mol_comp, 1e3)
         iscale.set_scaling_factor(self.temperature, 1e1)
+        iscale.set_scaling_factor(self.flow_mol_comp["Sc2(C2O4)3(s)"], 1e5)
 
     def get_material_flow_basis(self):
         return MaterialFlowBasis.molar

--- a/src/prommis/uky/costing/costing_dictionaries.py
+++ b/src/prommis/uky/costing/costing_dictionaries.py
@@ -241,17 +241,17 @@ def load_default_resource_prices():
         "H2SO4": convert_to_usd_2021(128.00, pyunits.USD_2023) / pyunits.tonne,
         # U.S. Annual Industrial price. https://www.eia.gov/dnav/ng/ng_pri_sum_dcu_nus_a.htm
         "natural_gas": convert_to_usd_2021(4.53e-3, pyunits.USD_2023) / pyunits.ft**3,
-        "polymer": 33.61 * 1e-6 * CE_index_units / pyunits.kg,
+        "polymer": 33.61 * CE_index_units / pyunits.kg,
         # (price year 2020) https://www.intratec.us/chemical-markets/caustic-soda-price.
         # Accessed 1/16/2025
         "NAOH": convert_to_usd_2021(350.00, pyunits.USD_2020) / pyunits.tonne,
         # (price year 2020) https://www.intratec.us/chemical-markets/calcium-carbonate-price.
         # Accessed 1/16/2025
         "CACO3": convert_to_usd_2021(1030.00, pyunits.USD_2020) / pyunits.tonne,
-        "coal_calcite": 0.50 * 1e-6 * CE_index_units / pyunits.tonne,
-        "HCL": 250.00 * 1e-6 * CE_index_units / pyunits.tonne,
-        "oxalic_acid": 1.00 * 1e-6 * CE_index_units / pyunits.kg,
-        "ascorbic_acid": 2.00 * 1e-6 * CE_index_units / pyunits.kg,
+        "coal_calcite": 0.50 * CE_index_units / pyunits.tonne,
+        "HCL": 250.00 * CE_index_units / pyunits.tonne,
+        "oxalic_acid": 1.00 * CE_index_units / pyunits.kg,
+        "ascorbic_acid": 2.00 * CE_index_units / pyunits.kg,
         # Annual average Kerosene price (2023). https://www.eia.gov/dnav/pet/hist/LeafHandler.
         # ashx?n=PET&s=EER_EPJK_PF4_RGC_DPG&f=A
         "kerosene": convert_to_usd_2021(2.699, pyunits.USD_2023) / pyunits.gallon,
@@ -260,8 +260,8 @@ def load_default_resource_prices():
         # (price year 2020) https://www.intratec.us/chemical-markets/sodium-sulfides-price.
         # Accessed 1/16/2025
         "NA2S": convert_to_usd_2021(655.00, pyunits.USD_2020) / pyunits.tonne,
-        "nonhazardous_solid_waste": 1.00 * 1e-6 * CE_index_units / pyunits.ton,
-        "nonhazardous_precipitate_waste": 5.00 * 1e-6 * CE_index_units / pyunits.ton,
-        "dust_and_volatiles": 1.00 * 1e-6 * CE_index_units / pyunits.ton,
+        "nonhazardous_solid_waste": 1.00 * CE_index_units / pyunits.ton,
+        "nonhazardous_precipitate_waste": 5.00 * CE_index_units / pyunits.ton,
+        "dust_and_volatiles": 1.00 * CE_index_units / pyunits.ton,
     }
     return default_resource_prices

--- a/src/prommis/uky/costing/costing_dictionaries.py
+++ b/src/prommis/uky/costing/costing_dictionaries.py
@@ -235,7 +235,7 @@ def load_default_resource_prices():
         # https://www.eia.gov/dnav/pet/pet_pri_gnd_dcus_nus_a.htm.
         # Diesel price annual average in U.S (2023).
         "diesel": convert_to_usd_2021(4.214, pyunits.USD_2023) / pyunits.gallon,
-        "bioleaching_solution": 0.008 * 1e-6 * CE_index_units / pyunits.L,
+        "bioleaching_solution": 0.008 * CE_index_units / pyunits.L,
         # Average price of year 2023. https://businessanalytiq.com/procurementanalytics/
         # index/sulfuric-acid-price-index/. Accessed 1/16/2025
         "H2SO4": convert_to_usd_2021(128.00, pyunits.USD_2023) / pyunits.tonne,

--- a/src/prommis/uky/costing/tests/test_ree_costing.py
+++ b/src/prommis/uky/costing/tests/test_ree_costing.py
@@ -1198,7 +1198,7 @@ class TestREECosting(object):
             10.916, rel=1e-4
         )
         assert value(model.fs.costing.total_variable_OM_cost[0]) == pytest.approx(
-            525.71, rel=1e-4
+            531.7451, rel=1e-4
         )
         assert value(model.fs.costing.land_cost) == pytest.approx(
             1.2247, rel=1e-4
@@ -1213,10 +1213,10 @@ class TestREECosting(object):
             -11.001142, rel=1e-4
         )
         assert value(model.fs.costing.pv_operating_cost) == pytest.approx(
-            -4614.5826, rel=1e-4
+            -4666.3511, rel=1e-4
         )
         assert value(model.fs.costing.pv_revenue) == pytest.approx(237.25943, rel=1e-4)
-        assert value(model.fs.costing.npv) == pytest.approx(-4501.10576, rel=1e-4)
+        assert value(model.fs.costing.npv) == pytest.approx(-4552.8743, rel=1e-4)
 
     @pytest.mark.unit
     def test_report(self, model):
@@ -2383,7 +2383,7 @@ class TestCustomCosting(object):
         )
 
         assert value(model.fs.costing.total_variable_OM_cost[0]) == pytest.approx(
-            530.67815, rel=1e-4
+            536.7120, rel=1e-4
         )
 
 
@@ -2893,7 +2893,7 @@ class TestDiafiltrationCosting(object):
         )
 
         assert value(model.fs.costing.total_variable_OM_cost[0]) == pytest.approx(
-            526.8958, rel=1e-4
+            532.9297, rel=1e-4
         )
 
 

--- a/src/prommis/uky/tests/test_uky_flowsheet.py
+++ b/src/prommis/uky/tests/test_uky_flowsheet.py
@@ -15,7 +15,6 @@ from pyomo.environ import (
     assert_optimal_termination,
     units,
     value,
-    Var,
 )
 from pyomo.network import Arc
 

--- a/src/prommis/uky/tests/test_uky_flowsheet.py
+++ b/src/prommis/uky/tests/test_uky_flowsheet.py
@@ -15,6 +15,7 @@ from pyomo.environ import (
     assert_optimal_termination,
     units,
     value,
+    Var,
 )
 from pyomo.network import Arc
 
@@ -610,8 +611,8 @@ def test_costing_solution(system_frame):
         "costing.total_installation_cost": {None: (5.51875e-01, tol, None)},
         "costing.other_plant_costs": {None: (4.78618e-06, tol, None)},
         "costing.total_fixed_OM_cost": {None: (6.80612e00, tol, None)},
-        "costing.total_variable_OM_cost": {0: (1.36131e00, tol, None)},
-        "costing.total_sales_revenue": {None: (2.69422e-5, None, tol)},
+        "costing.total_variable_OM_cost": {0: (1.36155e00, tol, None)},
+        "costing.total_sales_revenue": {None: (1.03978e-4, None, tol)},
         "costing.land_cost": {None: (6.1234e-5, tol, None)},
     }
     assert_solution_equivalent(model.fs, expected_results)
@@ -623,7 +624,30 @@ def test_costing_solution_diagnostics(system_frame):
 
     model = system_frame
     dt = DiagnosticsToolbox(model)
-    dt.assert_no_numerical_warnings()
+    # Relax numerical diagnostics to permit the three known variables that sit at their bounds
+    warnings, _ = dt._collect_numerical_warnings()
+    assert len(warnings) == 1
+    assert "Variables at or outside bounds" in str(warnings[0])
+
+    actual = sorted(
+        v.name
+        for v in model.component_data_objects(Var, descend_into=True)
+        if v.value is not None
+        and (
+            (v.has_lb() and v.value <= value(v.lb))
+            or (v.has_ub() and v.value >= value(v.ub))
+        )
+    )
+
+    expected = sorted(
+        [
+            "fs.precipitator.precipitate_state_block[0.0].flow_mol_comp['Sc2(C2O4)3(s)']",
+            "fs.sl_sep2.solid_state[0.0].flow_mol_comp['Sc2(C2O4)3(s)']",
+            "fs.roaster.solid_in[0.0].flow_mol_comp['Sc2(C2O4)3(s)']",
+        ]
+    )
+
+    assert actual == expected
 
 
 @pytest.mark.unit

--- a/src/prommis/uky/tests/test_uky_flowsheet.py
+++ b/src/prommis/uky/tests/test_uky_flowsheet.py
@@ -624,30 +624,7 @@ def test_costing_solution_diagnostics(system_frame):
 
     model = system_frame
     dt = DiagnosticsToolbox(model)
-    # Relax numerical diagnostics to permit the three known variables that sit at their bounds
-    warnings, _ = dt._collect_numerical_warnings()
-    assert len(warnings) == 1
-    assert "Variables at or outside bounds" in str(warnings[0])
-
-    actual = sorted(
-        v.name
-        for v in model.component_data_objects(Var, descend_into=True)
-        if v.value is not None
-        and (
-            (v.has_lb() and v.value <= value(v.lb))
-            or (v.has_ub() and v.value >= value(v.ub))
-        )
-    )
-
-    expected = sorted(
-        [
-            "fs.precipitator.precipitate_state_block[0.0].flow_mol_comp['Sc2(C2O4)3(s)']",
-            "fs.sl_sep2.solid_state[0.0].flow_mol_comp['Sc2(C2O4)3(s)']",
-            "fs.roaster.solid_in[0.0].flow_mol_comp['Sc2(C2O4)3(s)']",
-        ]
-    )
-
-    assert actual == expected
+    dt.assert_no_numerical_warnings()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Addresses Issue: 
Fix `costing_dictionaries.py` default resource prices that missed update with new definition of `CE_index_units`.

## Summary/Motivation:
This is to address the issue: https://github.com/prommis/prommis/issues/236

## Changes proposed in this PR:
- Updated associated default resource prices at `costing_dictionaries.py`
- Updated affected values in `test_ree_costing.py`

## Reviewer's checklist / merge requirements:
- [ ] The head branch (i.e. the "source" of the changes) is not the `main` branch on the PR author's fork
- [ ] Documentation
- [ ] Tests
- [ ] Diagnostic tests for models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
