### PR TITLE
Remove routing to prommis's root directory for pytest calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ known_issues = "prommis._testing_utils.known_issues"
 
 [tool.pytest.ini_options]
 addopts = """
---pyargs prommis
 --import-mode=importlib
 --cov=prommis
 --cov-config .coveragerc


### PR DESCRIPTION
## Addresses Issue: 
#245 


## Summary/Motivation:

Removes the `--pyargs prommis` option from `addopts` configuration for pytest, which affects how pytest discovers and runs tests. This makes it so that the directory you are in are where tests run.


## Changes proposed in this PR:
- Remove the `--pyargs prommis` option from `addopts` configuration for pytest
-

## Reviewer's checklist / merge requirements:
- [ ] The head branch (i.e. the "source" of the changes) is not the `main` branch on the PR author's fork
- [ ] Documentation
- [ ] Tests
- [ ] Diagnostic tests for models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.

2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
